### PR TITLE
HOTFIX: POST /api/category, adding no title is given to bad request cases

### DIFF
--- a/practice-app/server/src/api/controllers/category/createCategoryEndpoint.js
+++ b/practice-app/server/src/api/controllers/category/createCategoryEndpoint.js
@@ -9,7 +9,10 @@ export default async (req, res) => {
         return res.status(status).json({"resultMessage": resultMessage, "category": category});
     }catch(err) {
         let status = 500;
-        if(err.message == "\"title\" length must be at least 5 characters long")
+        if(
+            err.message == "\"title\" length must be at least 5 characters long" ||
+            err.message == "\"title\" is required"
+        )
             status = 400;
     
         return res.status(status).json({ "resultMessage": err.message });


### PR DESCRIPTION
As POST /api/category (This endpoint imports a title and converts it to a category) is implemented in #165, I forgot to send a bad request return code when a title is not given.

Made the necessary changes and now it is functional.