### PR TITLE
BUGFIX: Inserting beforeEach functions to describe body

### DIFF
--- a/practice-app/server/test/get_lessons_by_category.test.js
+++ b/practice-app/server/test/get_lessons_by_category.test.js
@@ -38,11 +38,11 @@ const addDummyData = async () => {
   await setLessons();
 };
 
-beforeEach(addDummyData);
 
 describe('GET /lesson/byCategory', () => {
   const byCategoryUrl = '/lesson/byCategory';
-
+  beforeEach(addDummyData);
+  
   it('should return validation error if the query parameter is not valid', (done) => {
     request(app)
       .get(byCategoryUrl)

--- a/practice-app/server/test/signup.test.js
+++ b/practice-app/server/test/signup.test.js
@@ -29,10 +29,10 @@ const addDummyUsers = (dummyDone) => {
   }).then(() => dummyDone());
 };
 
-beforeEach(addDummyUsers);
 
 describe('POST /user/signup', () => {
   const signupUrl = '/user/signup';
+  beforeEach(addDummyUsers);
 
   it('should return validation errors if the request body is not valid', (done) => {
     request(app)


### PR DESCRIPTION
Apparently if there is a beforeEach function executed outside of describe body and an exception occurs in that beforeEach, the exception can block all the tests.

Right now If I run tests in master branch I get the output of:
```

> bounswe2022group2-practice-app@1.0.0 test
> mocha

database url:  mongodb://localhost:27017/practiceApp
Server is running on 3000
Mongodb Connection
(node:3783) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)


  GET /lesson/byCategory
    1) "before each" hook: addDummyData for "should return validation error if the query parameter is not valid"


  0 passing (44ms)
  1 failing

  1) "before each" hook: addDummyData for "should return validation error if the query parameter is not valid":
     ValidationError: Category validation failed: title: Path `title` is required.
      at Document.invalidate (node_modules/mongoose/lib/document.js:2965:32)
      at /mnt/k/bounswe2022group2/practice-app/server/node_modules/mongoose/lib/document.js:2754:17
      at /mnt/k/bounswe2022group2/practice-app/server/node_modules/mongoose/lib/schematype.js:1333:9
      at process.processTicksAndRejections (node:internal/process/task_queues:77:11)
```

Whereas, with the changes suggested, the output turns to:
```
> bounswe2022group2-practice-app@1.0.0 test
> mocha

database url:  mongodb://localhost:27017/practiceApp
Server is running on 3000
Mongodb Connection
(node:3932) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)


  GET /lesson/byCategory
    1) "before each" hook: addDummyData for "should return validation error if the query parameter is not valid"

  POST /api/category
POST /category 200 6.414 ms - 160
    ✔ should add category when the title is valid (88ms)
POST /category 409 1.318 ms - 156
    ✔ should return 409 and existing category when the category already exists
POST /category 400 1.971 ms - 71
    ✔ should return 400 and error message when title is too short
POST /category 500 0.956 ms - 41
    2) should return 400 and error message when title does not exists

  POST /user/signup
POST /user/signup 400 2.100 ms - 51
    ✔ should return validation errors if the request body is not valid
POST /user/signup 409 5.205 ms - 69
    ✔ should not create a new user if the email already exists
POST /user/signup 200 100.441 ms - 220
    ✔ should sign up a user (105ms)


  6 passing (320ms)
  2 failing

  1) GET /lesson/byCategory
       "before each" hook: addDummyData for "should return validation error if the query parameter is not valid":
     ValidationError: Category validation failed: title: Path `title` is required.
      at Document.invalidate (node_modules/mongoose/lib/document.js:2965:32)
      at /mnt/k/bounswe2022group2/practice-app/server/node_modules/mongoose/lib/document.js:2754:17
      at /mnt/k/bounswe2022group2/practice-app/server/node_modules/mongoose/lib/schematype.js:1333:9
      at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

  2) POST /api/category
       should return 400 and error message when title does not exists:
     Error: expect(received).toBe(expected) // Object.is equality

Expected: 400
Received: 500
      at file:///mnt/k/bounswe2022group2/practice-app/server/test/post.category.test.js:120:28
      at /mnt/k/bounswe2022group2/practice-app/server/node_modules/supertest/lib/test.js:306:17
      at Test._assertFunction (node_modules/supertest/lib/test.js:285:13)
      at Test.assert (node_modules/supertest/lib/test.js:164:23)
      at Server.localAssert (node_modules/supertest/lib/test.js:120:14)
      at Object.onceWrapper (node:events:641:28)
      at Server.emit (node:events:527:28)
      at emitCloseNT (node:net:1736:8)
      at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
```

Since this changes are on @bahricanyesil 's part, I am only adding him as a reviewer due to possibility of a environment error on my behalf.