### PR TITLE
Implementing tests for GET /api/categories

### DIFF
--- a/practice-app/server/test/get_categories.test.js
+++ b/practice-app/server/test/get_categories.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'expect';
+import request from 'supertest';
+import axios from 'axios';
+import sinon from 'sinon';
+import app from './../src/app.js';
+import { Category } from '../src/models/index.js';
+
+const mockCategories = [
+    {
+    "title": "Calculus",
+    "description": "mockDescription"
+    },
+    {
+        "title": "Calculus",
+        "description": "mockDescription"
+    }
+]
+describe('GET /api/category', () => {
+
+    const categoryUrl = "/category";
+
+    afterEach(function () {
+        sinon.restore();
+    });
+    it('should return all categories', (done) => {
+        sinon.stub(Category, "find")
+            .onFirstCall().resolves(
+                mockCategories
+            );
+
+        request(app)
+            .get(categoryUrl)
+            .expect((res) => {
+                expect(res.status).toBe(200);
+                expect(res.body).toEqual(mockCategories);
+            })
+            .end(done);
+    });
+});


### PR DESCRIPTION
As discussed in #173, unit tests for GET /api/categories are implemented.

Implemented tests check for following cases:

- status =  200 : endpoint returns all the existing categories.