### PR TITLE
HOTFIX: POST /rating, null error between unit tests appearing on console fixed

### DIFF
--- a/practice-app/server/src/api/controllers/rating/createRating.js
+++ b/practice-app/server/src/api/controllers/rating/createRating.js
@@ -19,7 +19,6 @@ async function createRating(req) {
     .catch((err) => {
         return new Error('Lesson does not exist.');;
     });
-    console.log(existingLesson);
     const existingRating = await Rating.find({ lessonID: lessonID })
     .catch((err) => {
         return new Error(err.message);;


### PR DESCRIPTION
As POST /rating is implemented in https://github.com/bounswe/bounswe2022group2/issues/181, there were a "null" text in console between unit test results.

Made the necessary changes and now it does not appear.