### PR TITLE
Implementing tests for GET /rating

### DIFF
--- a/practice-app/server/test/get.ratings.test.js
+++ b/practice-app/server/test/get.ratings.test.js
@@ -45,4 +45,20 @@ it(`should return ratings between ${interval.min} and ${interval.max}`, (done) =
         })
         .end(done);
 });
+it(`should return 400 Bad Request when min or max interval is missing`, (done) => {
+    sinon.stub(Rating, "find")
+        .onFirstCall().resolves(
+            []
+        );
+    
+    request(app)
+        .get(ratingUrl)
+        .send({min:interval.min})
+        .expect((res) => {
+            expect(res.status).toBe(400);
+            expect(res.body.resultMessage).toMatch(/required/);
+    
+        })
+        .end(done);
+});
 });

--- a/practice-app/server/test/get.ratings.test.js
+++ b/practice-app/server/test/get.ratings.test.js
@@ -1,0 +1,48 @@
+import { expect } from 'expect';
+import request from 'supertest';
+import sinon from 'sinon';
+import app from './../src/app.js';
+import { Rating } from '../src/models/index.js';
+
+
+const interval = {
+  min: "2",
+  max: "8"
+}
+
+const mockRatings = [
+  {
+    lessonId: "ece",
+    rating: "2",
+  },
+  {
+    lessonID: "eae",
+    rating: "7",
+   
+  },
+];
+
+
+
+describe('GET /rating', () => {
+  const ratingUrl = '/rating';
+  afterEach(function () {
+    sinon.restore();
+});
+it(`should return ratings between ${interval.min} and ${interval.max}`, (done) => {
+    sinon.stub(Rating, "find")
+        .onFirstCall().resolves(
+            mockRatings
+        );
+    
+    request(app)
+        .get(ratingUrl)
+        .send({min:interval.min, max:interval.max})
+        .expect((res) => {
+            expect(res.status).toBe(200);
+            expect(res.body).toEqual(mockRatings);
+    
+        })
+        .end(done);
+});
+});


### PR DESCRIPTION
As discussed in https://github.com/bounswe/bounswe2022group2/issues/173, unit tests for GET /api/categories are implemented.

Implemented tests check for the following cases:

status 200 OK : endpoint returns the relevant ratings.
status 400 Bad Request: one of the request body arguments is missing.