### PR TITLE
implement GET lesson by lecturer endpoint

### DIFF
--- a/practice-app/server/src/api/controllers/lesson/get_lesson_by_lecturer.js
+++ b/practice-app/server/src/api/controllers/lesson/get_lesson_by_lecturer.js
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose';
+import { Lesson } from '../../../models/index.js';
+
+export default async (req, res) => {
+  const lecturerId = req.query.lecturer;
+  if (!lecturerId || !mongoose.isValidObjectId(lecturerId)) {
+    return res.status(400).json({ "resultMessage": "Please provide a valid lecturer id." });
+  }
+
+  const lessons = await Lesson.find({ lecturer: lecturerId })
+    .catch((err) => {
+      return res.status(500).json({ "resultMessage": err.message });
+    });
+
+  return res.status(200).json({
+    resultMessage: "Lessons are successfully fetched.",
+    lessons: lessons,
+  });
+};

--- a/practice-app/server/src/api/controllers/lesson/get_lesson_by_lecturer.js
+++ b/practice-app/server/src/api/controllers/lesson/get_lesson_by_lecturer.js
@@ -1,11 +1,17 @@
 import mongoose from 'mongoose';
 import { Lesson } from '../../../models/index.js';
+import { User } from '../../../models/index.js';
 
 export default async (req, res) => {
   const lecturerId = req.query.lecturer;
   if (!lecturerId || !mongoose.isValidObjectId(lecturerId)) {
     return res.status(400).json({ "resultMessage": "Please provide a valid lecturer id." });
   }
+
+  const lecturer = await User.findOne({ _id: lecturerId})
+  .catch((err) => {
+      return res.status(404).json({ "resultMessage": err.message });;
+  });
 
   const lessons = await Lesson.find({ lecturer: lecturerId })
     .catch((err) => {

--- a/practice-app/server/src/api/controllers/lesson/get_lesson_by_lecturer.js
+++ b/practice-app/server/src/api/controllers/lesson/get_lesson_by_lecturer.js
@@ -10,8 +10,12 @@ export default async (req, res) => {
 
   const lecturer = await User.findOne({ _id: lecturerId})
   .catch((err) => {
-      return res.status(404).json({ "resultMessage": err.message });;
+      return res.status(500).json({ "resultMessage": err.message });
   });
+
+  if(!lecturer){
+    return res.status(404).json({"resultMessage": "Lecturer with the given id could not be found."});
+  }
 
   const lessons = await Lesson.find({ lecturer: lecturerId })
     .catch((err) => {

--- a/practice-app/server/src/api/controllers/lesson/index.js
+++ b/practice-app/server/src/api/controllers/lesson/index.js
@@ -1,3 +1,4 @@
 export { default as getLessonsByCategory } from './get_lessons_by_category.js';
 export { default as getLessonsByName } from './get_lessons_by_name.js';
 export { default as getLessonEvents } from './get_lesson_events.js';
+export { default as getLessonByLecturer } from './get_lesson_by_lecturer.js';

--- a/practice-app/server/src/api/routes/lesson.js
+++ b/practice-app/server/src/api/routes/lesson.js
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import { getLessonsByCategory } from '../controllers/lesson/index.js';
 import { getLessonsByName } from '../controllers/lesson/index.js';
 import { getLessonEvents } from '../controllers/lesson/index.js';
+import { getLessonByLecturer } from '../controllers/lesson/index.js';
 
 const router = Router();
 
 router.get('/byCategory', getLessonsByCategory);
 router.get('/byName', getLessonsByName);
 router.get('/events', getLessonEvents);
+router.get('/byLecturer', getLessonByLecturer);
 
 export default router

--- a/practice-app/server/src/models/lesson.js
+++ b/practice-app/server/src/models/lesson.js
@@ -5,6 +5,7 @@ const { Schema, model } = mongoose;
 const lessonSchema = new Schema({
   name: { type: String, required: true },
   category_id: { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
+  lecturer: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true }
 },
   {
     timestamps: true,


### PR DESCRIPTION
This pull request contains the implementation regarding lesson creation: a GET endpoint /lesson/byLecturer. Issue regarding this is https://github.com/bounswe/bounswe2022group2/issues/239. Implementation will be tested using Postman.

After the implementation and testing stages are done, I will be preparing a documentation for the API regarding this GET endpoint.

NOTE: As this endpoint required the lesson model to have a lecturer, the model has also been modified. Create lesson endpoint was updated accordingly(see #238 )