### PR TITLE
HOTFIX: Changing the parameters of GET/rating and POST/rating endpoints 

### DIFF
--- a/practice-app/frontend/package-lock.json
+++ b/practice-app/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^0.27.2",
         "vue": "^3.2.33",
         "vue-router": "^4.0.15"
       },
@@ -239,6 +240,20 @@
       "integrity": "sha512-p4DO/JXwjs8klJyJL8Q2oM4ks5fUTze/h5k10oPPKMiLe1fj3G1QMzPHNmN1Py4ycOk7WlO2DcGXv1qiESJCZA==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -272,6 +287,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/css-render": {
       "version": "0.15.9",
@@ -315,6 +341,14 @@
       "dev": true,
       "peerDependencies": {
         "date-fns": ">=2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/diff-sequences": {
@@ -692,6 +726,38 @@
       "integrity": "sha512-tmiT1YUVqFjTY+BSBOAskL83xNx41iUfpvKP6Gcd/xMHjg3mnER98jXGXJyKnxCG19uPc6EhZiUC+MUyvoqCtw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -811,6 +877,25 @@
       "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/naive-ui": {
@@ -1311,6 +1396,20 @@
       "integrity": "sha512-p4DO/JXwjs8klJyJL8Q2oM4ks5fUTze/h5k10oPPKMiLe1fj3G1QMzPHNmN1Py4ycOk7WlO2DcGXv1qiESJCZA==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1335,6 +1434,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "css-render": {
       "version": "0.15.9",
@@ -1372,6 +1479,11 @@
       "integrity": "sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow==",
       "dev": true,
       "requires": {}
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff-sequences": {
       "version": "27.5.1",
@@ -1558,6 +1670,21 @@
       "integrity": "sha512-tmiT1YUVqFjTY+BSBOAskL83xNx41iUfpvKP6Gcd/xMHjg3mnER98jXGXJyKnxCG19uPc6EhZiUC+MUyvoqCtw==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1649,6 +1776,19 @@
       "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "requires": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "naive-ui": {

--- a/practice-app/frontend/package.json
+++ b/practice-app/frontend/package.json
@@ -7,6 +7,7 @@
     "preview": "vite preview --port 5050"
   },
   "dependencies": {
+    "axios": "^0.27.2",
     "vue": "^3.2.33",
     "vue-router": "^4.0.15"
   },

--- a/practice-app/frontend/src/route.js
+++ b/practice-app/frontend/src/route.js
@@ -2,8 +2,10 @@ import * as VueRouter from 'vue-router'
 
 import a from './components/a.vue'
 import b from './components/b.vue'
+import Rating from './components/Rating.vue'
 
 const routes = [
+    { path: '/rating', component: Rating },
     { path: '/', component: a },
     { path: '/b', component: b },
 ];

--- a/practice-app/server/src/api/controllers/rating/createRating.js
+++ b/practice-app/server/src/api/controllers/rating/createRating.js
@@ -12,10 +12,20 @@ async function createRating(req) {
     }
     var lessonFlag = mongoose.Types.ObjectId.isValid(req.lessonID);
     if(!lessonFlag){
-        throw new Error('Such an ID cannot exist.');
+        var existingLesson = await Lesson.findOne({name: req.lessonID})
+        .catch((err) => {
+            return new Error('Lesson does not exist.');;
+        });
+        if(!existingLesson){
+
+         throw new Error('Lesson does not exist.');
+
+        }else{
+            req.lessonID = existingLesson._id;
+        }
     }
     var lessonID = mongoose.Types.ObjectId(req.lessonID);
-    const existingLesson = await Lesson.findById(req.lessonID)
+    existingLesson = await Lesson.findById(req.lessonID)
     .catch((err) => {
         return new Error('Lesson does not exist.');;
     });
@@ -34,6 +44,7 @@ async function createRating(req) {
         let rating = new Rating({
         lessonID: lessonID,
         rating: req.rating,
+        name: existingLesson.name
     });
     if (existingRating.length > 0){
             var newRating = Number(req.rating)+ Number(existingRating[0].rating);

--- a/practice-app/server/src/api/controllers/rating/createRatingEndpoint.js
+++ b/practice-app/server/src/api/controllers/rating/createRatingEndpoint.js
@@ -9,8 +9,8 @@ export default async (req, res) => {
             return res.status(status).json({"resultMessage": resultMessage, "rating": rating});
         }catch(err) {
         let status = 500;
-        if(err.message == "Such an ID cannot exist.")
-            status = 400;
+        if(err.message == "Lesson does not exist.")
+            status = 404;
         return res.status(status).json({ "resultMessage": err.message });
     }
 };

--- a/practice-app/server/src/api/controllers/rating/getRatingEndpoint.js
+++ b/practice-app/server/src/api/controllers/rating/getRatingEndpoint.js
@@ -1,16 +1,27 @@
 import { Rating } from '../../../models/index.js';
+import Lesson from '../../../models/lesson.js';
 import { validateGetReqBody } from '../../validators/rating.validator.js';
 
 export default async (req, res) => {
     let status = 200;
-    const { error } = validateGetReqBody(req.body);
+    const { error } = validateGetReqBody(req.query);
     if(error) {
         status = 400;
         return res.status(status).json({ "resultMessage": error.message });
     }
-    const ratings = await Rating.find({rating: {$gte: req.body.min, $lte: req.body.max}}).catch(err=>{
+    const ratings = await Rating.find({rating: {$gte: req.query.min, $lte: req.query.max}})
+    .catch(err=>{
         return res.status(500).json({ "resultMessage": err.message });
+    });
+    ratings.forEach(async element => {
+        console.log(element);
+        console.log(element.lessonID);
+        console.log(element.lessonID.toString());
+        const lesson = await Lesson.findById(element.lessonID.toString());
+        element.name = lesson.name;
     });
     return res.status(200).json(ratings);
     
 };
+
+

--- a/practice-app/server/src/models/rating.js
+++ b/practice-app/server/src/models/rating.js
@@ -4,6 +4,7 @@ const { Schema, model } = mongoose;
 // We can add additional fields if we enlarge the features of the app.
 const ratingSchema = new Schema({
     lessonID:{ type: mongoose.Schema.Types.ObjectId, ref: 'Lesson', required: true },
+    name:{type:String},
     rating: {
         type: Number,
         required: true,
@@ -15,7 +16,9 @@ const ratingSchema = new Schema({
 ratingSchema.options.toJSON = {
     transform: function(doc, ret, options) {
         return {"id" : ret._id, 
-                "rating": ret.title, 
+                "lessonID"  : ret.lessonID,
+                "rating": ret.rating,   
+                "name":ret.name 
             }
     }
 };


### PR DESCRIPTION
As discussed in [meeting 9](), we should implement a frontend part for our endpoints. My GET request was expecting a body, however, implementing this with request or Axios libraries are not possible. In the newer version, GET/rating request accepts query parameters.
Since we want users to be able to rate lesson using their name, to provide usable interface, I must change the implementation of POST/rating endpoint since it accepts lessonID's from MongoDB in original version. In the newer version, it's possible to rate with name or id of a lesson.