### PR TITLE
HOTFIX: Fixing the implementation of GET/rating and POST/rating endpoints

### DIFF
--- a/practice-app/server/src/api/controllers/rating/createRating.js
+++ b/practice-app/server/src/api/controllers/rating/createRating.js
@@ -12,10 +12,20 @@ async function createRating(req) {
     }
     var lessonFlag = mongoose.Types.ObjectId.isValid(req.lessonID);
     if(!lessonFlag){
-        throw new Error('Such an ID cannot exist.');
+        var existingLesson = await Lesson.findOne({name: req.lessonID})
+        .catch((err) => {
+            return new Error('Lesson does not exist.');;
+        });
+        if(!existingLesson){
+
+         throw new Error('Lesson does not exist.');
+
+        }else{
+            req.lessonID = existingLesson._id;
+        }
     }
     var lessonID = mongoose.Types.ObjectId(req.lessonID);
-    const existingLesson = await Lesson.findById(req.lessonID)
+    existingLesson = await Lesson.findById(req.lessonID)
     .catch((err) => {
         return new Error('Lesson does not exist.');;
     });
@@ -34,6 +44,7 @@ async function createRating(req) {
         let rating = new Rating({
         lessonID: lessonID,
         rating: req.rating,
+        name: existingLesson.name
     });
     if (existingRating.length > 0){
             var newRating = Number(req.rating)+ Number(existingRating[0].rating);

--- a/practice-app/server/src/api/controllers/rating/createRatingEndpoint.js
+++ b/practice-app/server/src/api/controllers/rating/createRatingEndpoint.js
@@ -9,8 +9,8 @@ export default async (req, res) => {
             return res.status(status).json({"resultMessage": resultMessage, "rating": rating});
         }catch(err) {
         let status = 500;
-        if(err.message == "Such an ID cannot exist.")
-            status = 400;
+        if(err.message == "Lesson does not exist.")
+            status = 404;
         return res.status(status).json({ "resultMessage": err.message });
     }
 };

--- a/practice-app/server/src/api/controllers/rating/getRatingEndpoint.js
+++ b/practice-app/server/src/api/controllers/rating/getRatingEndpoint.js
@@ -1,16 +1,24 @@
 import { Rating } from '../../../models/index.js';
+import Lesson from '../../../models/lesson.js';
 import { validateGetReqBody } from '../../validators/rating.validator.js';
 
 export default async (req, res) => {
     let status = 200;
-    const { error } = validateGetReqBody(req.body);
+    const { error } = validateGetReqBody(req.query);
     if(error) {
         status = 400;
         return res.status(status).json({ "resultMessage": error.message });
     }
-    const ratings = await Rating.find({rating: {$gte: req.body.min, $lte: req.body.max}}).catch(err=>{
+    const ratings = await Rating.find({rating: {$gte: req.query.min, $lte: req.query.max}})
+    .catch(err=>{
         return res.status(500).json({ "resultMessage": err.message });
     });
+    ratings.forEach(async element => {
+ 
+        const lesson = await Lesson.findById(element.lessonID.toString());
+        element.name = lesson.name;
+    });
     return res.status(200).json(ratings);
-    
+
 };
+

--- a/practice-app/server/src/models/rating.js
+++ b/practice-app/server/src/models/rating.js
@@ -1,24 +1,31 @@
-import mongoose from 'mongoose';
+import mongoose from "mongoose";
 const { Schema, model } = mongoose;
 
 // We can add additional fields if we enlarge the features of the app.
 const ratingSchema = new Schema({
-    lessonID:{ type: mongoose.Schema.Types.ObjectId, ref: 'Lesson', required: true },
-    rating: {
-        type: Number,
-        required: true,
-    },
-      versionKey: false
+  lessonID: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Lesson",
+    required: true,
+  },
+  name: { type: String },
+  rating: {
+    type: Number,
+    required: true,
+  },
+  versionKey: false,
 });
 
-
 ratingSchema.options.toJSON = {
-    transform: function(doc, ret, options) {
-        return {"id" : ret._id, 
-                "rating": ret.title, 
-            }
-    }
+  transform: function (doc, ret, options) {
+    return {
+      id: ret._id,
+      lessonID: ret.lessonID,
+      rating: ret.rating,
+      name: ret.name,
+    };
+  },
 };
-const Rating = model('Rating', ratingSchema);
+const Rating = model("Rating", ratingSchema);
 
 export default Rating;

--- a/practice-app/server/test/get.ratings.test.js
+++ b/practice-app/server/test/get.ratings.test.js
@@ -25,7 +25,8 @@ const mockRatings = [
 
 
 describe('GET /rating', () => {
-  const ratingUrl = '/rating';
+  const ratingUrl = `/rating?min=${interval.min}&max=${interval.max}`;
+  const dummyRatingUrl = `/rating?min=${interval.min}`;
   afterEach(function () {
     sinon.restore();
 });
@@ -37,7 +38,6 @@ it(`should return ratings between ${interval.min} and ${interval.max}`, (done) =
     
     request(app)
         .get(ratingUrl)
-        .send({min:interval.min, max:interval.max})
         .expect((res) => {
             expect(res.status).toBe(200);
             expect(res.body).toEqual(mockRatings);
@@ -52,8 +52,7 @@ it(`should return 400 Bad Request when min or max interval is missing`, (done) =
         );
     
     request(app)
-        .get(ratingUrl)
-        .send({min:interval.min})
+        .get(dummyRatingUrl)
         .expect((res) => {
             expect(res.status).toBe(400);
             expect(res.body.resultMessage).toMatch(/required/);

--- a/practice-app/server/test/post.rating.test.js
+++ b/practice-app/server/test/post.rating.test.js
@@ -6,11 +6,7 @@ import { Rating } from '../src/models/index.js';
 import { Lesson } from '../src/models/index.js';
 
 const mockRating = {
-  "lessonID": "62815d7535b0cdc89d74ab1a",
-  "rating": "2.5"
-}
-const mockHexRating = {
-  "lessonID": "62815d7535b0cdc89d74ab1r",
+  "lessonID": "ilginç",
   "rating": "2.5"
 }
 const trueRating = {
@@ -69,24 +65,24 @@ describe('POST/rating', () => {
 
 
       
-      it('should return 400 and error message when an ID is not a valid Mongoose Object ID', (done) => {
-        sinon.stub(Rating, "findById")
-        .onFirstCall().resolves(
-        new Error()
-      );
-      request(app)
-      .post(ratingUrl)
-      .send({
-        lessonID: mockHexRating.lessonID,
-        rating: mockHexRating.rating
-      })
-      .expect((res) => {
-        expect(res.status).toBe(400);
-        expect(res.body.resultMessage).toMatch(/cannot exist./);
+    //   it('should return 400 and error message when an ID is not a valid Mongoose Object ID', (done) => {
+    //     sinon.stub(Rating, "findById")
+    //     .onFirstCall().resolves(
+    //     new Error()
+    //   );
+    //   request(app)
+    //   .post(ratingUrl)
+    //   .send({
+    //     lessonID: mockHexRating.lessonID,
+    //     rating: mockHexRating.rating
+    //   })
+    //   .expect((res) => {
+    //     expect(res.status).toBe(400);
+    //     expect(res.body.resultMessage).toMatch(/cannot exist./);
         
-      })
-      .end(done);
-    });
+    //   })
+    //   .end(done);
+    // });
       it('should return 404 and error message when Lesson does not exist', (done) => {
         sinon.stub(Rating, "findById")
         .onFirstCall().resolves(


### PR DESCRIPTION
As I mentioned in #241 , implementation for mentioned endpoints have been changed to provide a more clear user interface. As a result of new status and scenarios in endpoints, the testing of them also must be changed. In this version,
GET/rating
status 200: filtered ratings are returned with query parameters.
status 400: no filtering value entered, bad request.

POST/rating
status 200: rating was successfully created
status 404: lesson does not exist.

