### PR TITLE
Practice App: Implement Create Event Page

### DIFF
--- a/practice-app/frontend/src/App.vue
+++ b/practice-app/frontend/src/App.vue
@@ -7,6 +7,7 @@
           <div class="topnav">
             <router-link v-if="authenticated" to="/category">Categories</router-link>
             <router-link v-if="authenticated" to="/rating">Ratings</router-link>
+            <router-link v-if="authenticated" to="/create-event">Create Event</router-link>
           </div>
           <router-view @authenticated="setAuthenticated" />
         </n-dialog-provider>

--- a/practice-app/frontend/src/components/Event.vue
+++ b/practice-app/frontend/src/components/Event.vue
@@ -1,0 +1,149 @@
+<template>
+  <div>
+    <form @submit.prevent="createEvent">
+      <div>
+        <label for="title">title</label>
+        <input name="title" v-model="title" placeholder="Enter event title">
+      </div>
+      <div>
+        <label for="description">description</label>
+        <input name="description" v-model="description" placeholder="Enter description">
+      </div>
+      <div>
+        <label for="date">date</label>
+        <input name="date" v-model="date" placeholder="Enter date in form of MM-DD-YYY" type="date">
+      </div>
+      <div>
+          <label for="location">location</label>
+          <input name="location" v-model="location" placeholder="Enter the location of event">
+      </div>
+      <div>
+          <label for="lesson_id">lesson_id</label>
+          <input name="lesson_id" v-model="lesson_id" placeholder="Lesson ID">
+      </div>
+      <br>
+      <div class="button">
+        <button class="submit" type="submit">Create Event</button>
+      </div>
+      <br>
+    </form>
+  </div>
+</template>
+
+<script>
+
+
+export default {
+  watch: {
+  },
+  name: "App",
+  data() {
+      return {
+          title: "",
+          description: "",
+          date: "",
+          location: "",
+          lesson_id: "",
+          host_id: localStorage.getItem('userId'),
+        };
+  },
+  methods: {
+    async createEvent() {
+        const { title, description, date, location, lesson_id, host_id } = this;
+        try {
+        const res = await fetch(
+            "http://localhost:3000/event/createEvent",
+            {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+                title, description, date, location, lesson_id, host_id
+            })
+            }
+        );
+        const data = await res.json();
+        if (res.status == 200) {
+            this.$emit("eventCreated", true);
+            this.$router.replace({ name: "CreateEvent" });
+            alert(data.resultMessage);
+        } else {
+            alert(data.resultMessage);
+        }
+        } catch (err) {
+        alert(err);
+        }
+    },
+  },
+};
+</script>
+
+
+<style scoped>
+form {
+  max-width: 600px;
+  margin: 30px auto;
+  background: #fff;
+  text-align: left;
+  padding: 20px;
+  border-radius: 10px;
+}
+
+label {
+  color: #aaa;
+  display: inline-block;
+  margin: 25px 0 15px;
+  text-transform: uppercase;
+}
+
+input,
+select {
+  display: block;
+  padding: 10px 6px;
+  width: 100%;
+  box-sizing: bordre-box;
+  border: none;
+  border-bottom: 1px solid #ddd;
+  color: #555;
+}
+
+input[type="checkbox"] {
+  display: inline-block;
+  width: 16px;
+  margin: 0 10px 0;
+  position: relative;
+  top: 2px;
+}
+
+.pill {
+  display: inline-block;
+  margin: 20px 10px 0 0;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 12px;
+  cursor: pointer;
+  background: #eee;
+}
+
+button {
+  background: rgb(7, 24, 7);
+  border: 0;
+  padding: 10px 20px;
+  color: white;
+  border-radius: 20px;
+}
+
+.submit {
+  text-align: center;
+}
+
+.error {
+  color: #ff0000;
+  margin-top: 10px;
+  font-size: 0.8em;
+  font-weight: bold;
+}
+</style>
+
+

--- a/practice-app/frontend/src/components/Event.vue
+++ b/practice-app/frontend/src/components/Event.vue
@@ -44,7 +44,7 @@ export default {
           date: "",
           location: "",
           lesson_id: "",
-          host_id: localStorage.getItem('userId'),
+          host_id: localStorage.getItem('user_id'),
         };
   },
   methods: {

--- a/practice-app/frontend/src/components/Signup.vue
+++ b/practice-app/frontend/src/components/Signup.vue
@@ -58,7 +58,7 @@ export default {
         const data = await res.json();
         if (res.status == 200) {
           this.$emit("authenticated", true);
-          localStorage.setItem('user_id', data.user._id);
+          localStorage.setItem('user_id', data.user.id);
           this.$router.replace({ name: "Categories" });
         } else {
           alert(data.resultMessage);

--- a/practice-app/frontend/src/components/Signup.vue
+++ b/practice-app/frontend/src/components/Signup.vue
@@ -58,6 +58,7 @@ export default {
         const data = await res.json();
         if (res.status == 200) {
           this.$emit("authenticated", true);
+          localStorage.setItem('user_id', data.user._id);
           this.$router.replace({ name: "Categories" });
         } else {
           alert(data.resultMessage);

--- a/practice-app/frontend/src/route.js
+++ b/practice-app/frontend/src/route.js
@@ -4,12 +4,14 @@ import Rating from './components/Rating.vue'
 import Category from './components/Category.vue';
 import Login from './components/Login.vue';
 import Signup from './components/Signup.vue';
+import Event from './components/Event.vue';
 
 const routes = [
     { path: '/', component: Signup, name: "Signup" },
     { path: '/category', component: Category, name: "Categories" },
     { path: '/login', component: Login, name: "Login" },
     { path: '/rating', component: Rating },
+    { path: '/create-event', component: Event, name: "CreateEvent" },
 ];
 
 const router = VueRouter.createRouter({


### PR DESCRIPTION
As mentioned in the issue #220, I took the responsibility of implementation of the creating events page of our practice app. Before starting to develop the create event page, I created the corresponding POST endpoint and its unit tests. After being sure that the endpoint works successfully and after testing it with both unit tests and via postman manually, I started to develop the create event page with the Vue.js framework according to the team's decision.

This pull request includes the following actions:
1. Creating a form formation to get required fields for creating an event. Those fields include:
    * Event title
    * Description
    * Date
    * Location
    * Lesson ID
 2. Storing the user_id after signup and passing it to the api request.
 3. Connecting the POST event/createEvent endpoint to the create event button.
 4. Checking possible response errors and showing an alert dialog both for success and error.
 5. Navigating to the CreateEvent screen on success case.

This PR closes #220, other details can also be seen from that issue.