### PR TITLE
Practice App: Implement Attended Events Page

### DIFF
--- a/practice-app/frontend/src/App.vue
+++ b/practice-app/frontend/src/App.vue
@@ -7,6 +7,8 @@
           <div class="topnav">
             <router-link v-if="authenticated" to="/category">Categories</router-link>
             <router-link v-if="authenticated" to="/rating">Ratings</router-link>
+            <router-link v-if="authenticated" to="/create-event">Create Event</router-link>
+            <router-link v-if="authenticated" to="/attended-events">Attended Events</router-link>
           </div>
           <router-view @authenticated="setAuthenticated" />
         </n-dialog-provider>
@@ -17,13 +19,9 @@
 
 
 <script>
-
 import { darkTheme, NConfigProvider, NDialogProvider, NGlobalStyle, NMessageProvider, NNotificationProvider } from 'naive-ui'
 import { defineComponent } from 'vue'
 import { RouterLink, RouterView } from 'vue-router'
-
-
-
 export default defineComponent({
   name: 'App',
   data() {
@@ -49,7 +47,11 @@ export default defineComponent({
     return {
       darkTheme
     }
-  }
+  },
+  created() {
+    localStorage.setItem('authenticated', false);
+    this.authenticated = localStorage.getItem('authenticated');
+  },
 })
 </script>
 
@@ -58,7 +60,6 @@ export default defineComponent({
   background-color: #333;
   overflow: hidden;
 }
-
 /* Style the links inside the navigation bar */
 .topnav a {
   float: left;

--- a/practice-app/frontend/src/components/AttendedEvents.vue
+++ b/practice-app/frontend/src/components/AttendedEvents.vue
@@ -1,0 +1,63 @@
+<template>
+    <div style="margin: 25px 50px 75px 100px">
+        <n-list bordered>
+            <template #header>
+                <h1>Attended Events</h1>
+            </template>
+            <n-list-item v-for="event in events">
+                <template #prefix>
+                    <n-tag type="success" size="large" round>
+                        {{ event[0].title }}
+                    </n-tag>
+                </template>
+                <n-thing>
+                    <b>Date (yyyy-mm-dd): </b>{{ event[0].date.substr(0, 10) }}<br>
+                    <b>Location: </b>{{ event[0].location }}<br>
+                    <b>Lesson ID: </b>{{ event[0].lesson_id }}<br>
+                </n-thing>
+            </n-list-item>
+        </n-list>
+    </div>
+</template>
+
+
+
+
+<script>
+import { defineComponent } from 'vue'
+import { NButton, NList, NListItem, NThing, NTag, NInput, NSpace, useMessage } from 'naive-ui'
+
+var url = import.meta.env.VITE_API_URL + '/user/attendedEvents' + "?user_id=" + localStorage.getItem('user_id');
+export default defineComponent({
+    data() {
+        return {
+            "events": []
+        }
+    },
+    methods: {
+        async getAttendedEvents() {
+            fetch(url)
+                .then(response => response.json())
+                .then(data => {
+                    console.log(data)
+                    this.events = data.events
+                });
+        },
+    },
+    setup() {
+        const message = useMessage()
+        return {
+            showMessage(m) {
+                message.info(m)
+            }
+        };
+    },
+    async created() {
+        console.log(url)
+        this.getAttendedEvents()
+    },
+    components: {
+        NButton, NList, NListItem, NThing, NTag, NInput, NSpace
+    }
+})
+</script>

--- a/practice-app/frontend/src/route.js
+++ b/practice-app/frontend/src/route.js
@@ -1,15 +1,23 @@
 import * as VueRouter from 'vue-router';
-
-import Rating from './components/Rating.vue'
 import Category from './components/Category.vue';
+import CategoryLessons from './components/CategoryLessons.vue';
 import Login from './components/Login.vue';
+import Rating from './components/Rating.vue';
 import Signup from './components/Signup.vue';
+import Event from './components/Event.vue';
+import AttendedEvents from './components/AttendedEvents.vue';
+
 
 const routes = [
-    { path: '/', component: Signup, name: "Signup" },
-    { path: '/category', component: Category, name: "Categories" },
+    { path: '/', component: Signup, name: "Signup", props: true, },
+    { path: '/category', component: Category, name: "Categories", props: true, },
+    {
+        path: '/categoryLessons', component: CategoryLessons, name: "CategoryLessons", props: true,
+    },
     { path: '/login', component: Login, name: "Login" },
     { path: '/rating', component: Rating },
+    { path: '/create-event', component: Event, name: "CreateEvent" },
+    { path: '/attended-events', component: AttendedEvents, name: "AttendedEvents" },
 ];
 
 const router = VueRouter.createRouter({


### PR DESCRIPTION
As mentioned in the issue #221 , I took the responsibility of implementation of the viewing attended events page of our practice app. Before starting to develop the attended events page, I created the corresponding GET endpoint and its unit tests. After being sure that the endpoint works successfully and after testing it with both unit tests and via postman manually, I started to develop the attended events page with the Vue.js framework according to the team's decision.

This pull request includes the following actions:
1. Creating a list formation to displayed fetched events.
2. Accessing the user_id of the user in the session to get their attended events.
3. Connecting the GET user/attendedEvents endpoint to the Attended Events button on the main navigation.
4. Checking possible response errors and showing an alert dialog.
5. Navigating to the Attended Events screen on success case.

This PR closes #221, other details can also be seen from that issue.