### PR TITLE
Bugfix: Removing double imports

### DIFF
--- a/practice-app/server/src/api/routes/lesson.js
+++ b/practice-app/server/src/api/routes/lesson.js
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import { getLessonsByCategory, createLessonEndpoint } from '../controllers/lesson/index.js';
-import { getLessonsByCategory } from '../controllers/lesson/index.js';
 import { getLessonsByName } from '../controllers/lesson/index.js';
 import { getLessonEvents } from '../controllers/lesson/index.js';
 import { getLessonByLecturer } from '../controllers/lesson/index.js';


### PR DESCRIPTION
Since we are importing getLessonsByCategory twice, npm starts results in a syntax error both in my local and the docker container.