### PR TITLE
Bugfix drop lesson and get lesson events test update due to lesson model change

### DIFF
--- a/practice-app/server/test/drop_lesson.test.js
+++ b/practice-app/server/test/drop_lesson.test.js
@@ -7,6 +7,7 @@ import app from './../src/app.js';
 const categoryId = mongoose.Types.ObjectId();
 const lesson_ids = [mongoose.Types.ObjectId(), mongoose.Types.ObjectId(), mongoose.Types.ObjectId()];
 const user_ids = [mongoose.Types.ObjectId(), mongoose.Types.ObjectId()];
+const lecturer_ids = [mongoose.Types.ObjectId(), mongoose.Types.ObjectId()];
 const invalid_ids = [mongoose.Types.ObjectId(), mongoose.Types.ObjectId()];
 
 const category = {
@@ -19,17 +20,20 @@ const lessons = [
   {
     _id: lesson_ids[0],
     name: "Lesson1",
-    category_id: category._id
+    category_id: category._id,
+    lecturer: lecturer_ids[0]
   },
   {
     _id: lesson_ids[1],
     name: "Lesson2",
-    category_id: category._id
+    category_id: category._id,
+    lecturer: lecturer_ids[0]
   },
   {
     _id: lesson_ids[2],
     name: "Lesson3",
-    category_id: category._id
+    category_id: category._id,
+    lecturer: lecturer_ids[1]
   }
 ];
 
@@ -39,14 +43,16 @@ const users = [
         email: "user1@gmail.com",
         password: "password1",
         name: "username1",
-        enrolledLessons: [lesson_ids[0],lesson_ids[1],lesson_ids[2]]
+        enrolledLessons: [lesson_ids[0],lesson_ids[1],lesson_ids[2]],
+        attendedEvents: []
     },
     {
         _id: user_ids[1],
         email: "user2@gmail.com",
         password: "password2",
         name: "username2",
-        enrolledLessons: [lesson_ids[1],lesson_ids[2]]
+        enrolledLessons: [lesson_ids[1],lesson_ids[2]],
+        attendedEvents: []
     }
 ]
 

--- a/practice-app/server/test/get_lesson_events.test.js
+++ b/practice-app/server/test/get_lesson_events.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'expect';
-import mongoose from 'mongoose';
+import mongoose, { mongo } from 'mongoose';
 import request from 'supertest';
 import { Category, User, Lesson, Event } from '../src/models/index.js';
 import app from './../src/app.js';
@@ -7,6 +7,7 @@ import app from './../src/app.js';
 const categoryId = mongoose.Types.ObjectId();
 const lesson_ids = [mongoose.Types.ObjectId(), mongoose.Types.ObjectId()];
 const user_ids = [mongoose.Types.ObjectId(), mongoose.Types.ObjectId()];
+const lecturer_ids = [mongoose.Types.ObjectId(), mongoose.Types.ObjectId()];
 const event_ids = [mongoose.Types.ObjectId(), mongoose.Types.ObjectId(), mongoose.Types.ObjectId()];
 const dates = [new Date(2022,4,23), new Date(2022,5,19), new Date(2022,10,29)];
 const invalid_id = mongoose.Types.ObjectId();
@@ -21,12 +22,14 @@ const lessons = [
   {
     _id: lesson_ids[0],
     name: "Lesson1",
-    category_id: category._id
+    category_id: category._id,
+    lecturer: lecturer_ids[0]
   },
   {
     _id: lesson_ids[1],
     name: "Lesson2",
-    category_id: category._id
+    category_id: category._id,
+    lecturer: lecturer_ids[1]
   },
 ];
 

--- a/practice-app/server/test/get_lesson_events.test.js
+++ b/practice-app/server/test/get_lesson_events.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'expect';
-import mongoose, { mongo } from 'mongoose';
+import mongoose from 'mongoose';
 import request from 'supertest';
 import { Category, User, Lesson, Event } from '../src/models/index.js';
 import app from './../src/app.js';


### PR DESCRIPTION
Due to change in Lesson model, my tests were failing because Lesson documents did not include lecturer field. In this PR, I corrected it.