### PR TITLE
BUGFIX: Update lesson item by adding lecturer id column

### DIFF
--- a/practice-app/frontend/src/components/CategoryLessons.vue
+++ b/practice-app/frontend/src/components/CategoryLessons.vue
@@ -13,13 +13,11 @@
               <th>Lecturer Id</th>
             </tr>
           </template>
-          <n-list-item v-for="lesson in lessons">
-            <tr v-for="(lesson, i) in lessons" :key="lesson.id">
-              <td>{{ i + 1 }}</td>
-              <td>{{ lesson.id }}</td>
-              <td>{{ lesson.name }}</td>
-              <td>{{ lesson.lecturer }}</td>
-            </tr>
+          <n-list-item v-for="(lesson, i) in lessons">
+            <td>{{ i + 1 }}</td>
+            <td>{{ lesson.id }}</td>
+            <td>{{ lesson.name }}</td>
+            <td>{{ lesson.lecturer }}</td>
           </n-list-item>
         </n-list>
       </div>

--- a/practice-app/frontend/src/components/CategoryLessons.vue
+++ b/practice-app/frontend/src/components/CategoryLessons.vue
@@ -8,8 +8,9 @@
               Lessons of the {{ selectedCate.title }} Category</h1>
             <tr>
               <th>Item Index</th>
-              <th>Id</th>
-              <th>Name</th>
+              <th>Lesson Id</th>
+              <th>Lesson Name</th>
+              <th>Lecturer Id</th>
             </tr>
           </template>
           <n-list-item v-for="lesson in lessons">
@@ -17,6 +18,7 @@
               <td>{{ i + 1 }}</td>
               <td>{{ lesson.id }}</td>
               <td>{{ lesson.name }}</td>
+              <td>{{ lesson.lecturer }}</td>
             </tr>
           </n-list-item>
         </n-list>
@@ -35,6 +37,7 @@ export default {
           "id": "id",
           "category_id": "id",
           "name": "name",
+          "lecturer": "lecturer_id",
         }
       ],
       selectedCate: {


### PR DESCRIPTION
After I created the lessons by category screen, there occurred a model update from the other teammates. To be on the same way and successfully show all the fields, I updated the lesson item by adding the lecturer id column and configured it to be compatible with our updated lesson model.