### PR TITLE
Practice App: Create Get Event Details Screen, Update getEventDetails and Test Part

### DIFF
--- a/practice-app/frontend/src/App.vue
+++ b/practice-app/frontend/src/App.vue
@@ -10,6 +10,7 @@
             <router-link v-if="authenticated" to="/create-event">Create Event</router-link>
             <router-link v-if="authenticated" to="/attend">Attend Event</router-link>
             <router-link v-if="authenticated" to="/attended-events">Attended Events</router-link>
+            <router-link v-if="authenticated" to="/get-event-details">Get Event Details</router-link>
             <router-link v-if="authenticated" to="/enrolled-lessons">Enrolled Lessons</router-link>
             <router-link v-if="authenticated" to="/search-lesson">Search Lesson</router-link>
             <router-link v-if="authenticated" to="/lesson-events">Lesson Events</router-link>

--- a/practice-app/frontend/src/components/GetEventDetails.vue
+++ b/practice-app/frontend/src/components/GetEventDetails.vue
@@ -1,0 +1,89 @@
+<template>
+    <div style="margin: 25px 50px 75px 50px">
+        <n-list bordered>
+            <template #header>
+                <h1>Event Details</h1>
+            </template>
+            <template #footer>
+                <n-space vertical>
+                    <n-input size="large" round clearable placeholder="Enter an event id to get its details" @change="handleInput" />
+                </n-space>
+            </template>
+            <n-list-item v-for="event in event">
+                <template #prefix>
+                    <n-tag type="success" size="large" round>
+                        {{ event.title }}
+                    </n-tag>
+                </template>
+                <n-thing>
+                    <b>Date (yyyy-mm-dd): </b>{{ event.date.substr(0, 10) }}<br>
+                    <b>Location: </b>{{ event.location }}<br>
+                    <b>Host ID: </b>{{ event.host_id }}<br>
+                    <b>Lesson ID: </b>{{ event.lesson_id }}<br>
+                </n-thing>
+            </n-list-item>
+        </n-list>
+    </div>
+</template>
+
+
+
+
+<script>
+import { defineComponent } from 'vue'
+import { NButton, NList, NListItem, NThing, NTag, NInput, NSpace, useMessage } from 'naive-ui'
+
+var url = "";
+export default defineComponent({
+    data() {
+        return {
+            "event": []
+        }
+    },
+    methods: {
+        async getDetails(eventId) {
+            try {
+                const res = await fetch(
+                    import.meta.env.VITE_API_URL + '/event/details/' + `?event_id=${eventId}`,
+                    {
+                        method: "GET",
+                        headers: {
+                            "Content-Type": "application/json"
+                        },
+                    }
+                );
+                const data = await res.json();
+                if (res.status == 200) {
+                    this.event = data.event;
+                    this.showMessage(data.resultMessage);
+                    this.$emit("getDetailsFetched", true);
+                    this.$router.replace({ name: "GetEventDetails" });
+                } else {
+                    this.showMessage(data.resultMessage);
+                }
+            } catch (err) {
+                this.showMessage(err);
+            }
+        },
+
+        handleInput(v) {
+            this.getDetails(v)
+        },
+
+    },
+    setup() {
+        const message = useMessage()
+        return {
+            showMessage(m) {
+                message.info(m)
+            }
+        };
+    },
+    async created() {
+        console.log(url);
+    },
+    components: {
+        NButton, NList, NListItem, NThing, NTag, NInput, NSpace
+    }
+})
+</script>

--- a/practice-app/frontend/src/route.js
+++ b/practice-app/frontend/src/route.js
@@ -10,6 +10,7 @@ import AttendedEvents from './components/AttendedEvents.vue';
 import EnrolledLessons from "./components/EnrolledLessons.vue";
 import SearchLesson from './components/SearchLesson.vue';
 import LessonEvents from './components/LessonEvents.vue';
+import GetEventDetails from './components/GetEventDetails.vue';
 
 
 const routes = [
@@ -21,6 +22,7 @@ const routes = [
     { path: '/create-event', component: Event, name: "CreateEvent" },
     { path: '/attend', component: Attend, name: "Attend" },
     { path: '/attended-events', component: AttendedEvents, name: "AttendedEvents" },
+    { path: '/get-event-details', component: GetEventDetails, name: "GetEventDetails"},
     { path: '/enrolled-lessons', component: EnrolledLessons, name: "EnrolledLessons"},
     { path: '/search-lesson', component: SearchLesson, name: "SearchLesson"},
     { path: '/lesson-events', component: LessonEvents, name: "LessonEvents"},

--- a/practice-app/server/src/api/controllers/event/getEventDetails.js
+++ b/practice-app/server/src/api/controllers/event/getEventDetails.js
@@ -7,15 +7,16 @@ export default async (req,res) => {
         return res.status(400).json({ "resultMessage": "Please provide a valid event id." });
     }
 
-    const event = await Event.findById(eventId)
+    const event = await Event.find({ _id: eventId })
     .catch(err => {
         return res.status(500).json({"resultMessage": err.message});
     });
-
-    if(!event) return res.status(404).json({"resultMessage": "Event with the given event id does not exist"});
-
+    
+    if (event.length != 0)
     return res.status(200).json({
-        resultMessage: "Event is successfully fetched.",
-        event: event,
+      resultMessage: "Event is successfully fetched.",
+      event: event,
     });
+  
+  return res.status(404).json({ "resultMessage": "Event with the given event id does not exist."});
 } 

--- a/practice-app/server/test/get_event_details.test.js
+++ b/practice-app/server/test/get_event_details.test.js
@@ -85,7 +85,7 @@ describe('GET /event/details', () => {
       .expect((res) => {
         expect(res.body.event).not.toBeNull();
         expect(res.body.event).not.toBeUndefined();
-        const firstEvent = res.body.event;
+        const firstEvent = res.body.event[0];
         expect(firstEvent).not.toBeNull();
         expect(firstEvent).not.toBeUndefined();
         expect(firstEvent.title).not.toBeNull();
@@ -110,7 +110,7 @@ describe('GET /event/details', () => {
       .expect((res) => {
         expect(res.body.event).not.toBeNull();
         expect(res.body.event).not.toBeUndefined();
-        const firstEvent = res.body.event;
+        const firstEvent = res.body.event[0];
         expect(firstEvent).not.toBeNull();
         expect(firstEvent).not.toBeUndefined();
         expect(firstEvent.title).not.toBeNull();


### PR DESCRIPTION
As mentioned in the issue #299 , I took the responsibility of implementation of the get specific event details page of our practice app. Before starting to develop the get specific event details page, I created the corresponding endpoints and their unit tests. After being sure that the endpoints work successfully and after testing it with both unit tests and via postman manually, I started to develop the get specific event details page with the Vue.js framework according to the team's decision.

I also updated some parts of the getEventDetails.js and get_event_details.test.js so as to eliminate the error I had previously gotten. All the tests for the parts I am responsible run perfectly now.

This PR includes:
* Sending POST requests to our backend server via correct parameters
* Implementation of the attend event page functionality.

This PR closes #299 , other details can also be seen from that issue.