### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
+contact_links:
+  - name: bounswe2022group2 Wiki
+    url: https://github.com/bounswe/bounswe2022group2/wiki
+    about: You can see the details of our repository here.

--- a/.github/ISSUE_TEMPLATE/generic_template.yml
+++ b/.github/ISSUE_TEMPLATE/generic_template.yml
@@ -1,6 +1,7 @@
 name: Generic Template
 description: It can be used for any issue since it contains the general requirements
-labels: status-new,priority-medium
+assignees: ['bahricanyesil']
+labels: [status-new,priority-medium]
 body:
   - type: markdown
     attributes:
@@ -56,7 +57,8 @@ body:
         - Onur Kömürcü
         - Mehmet Batuhan Çelik
         - Hasan Can Erol
-        - Ahmet Yiğit Özdoğan
+        - Koray Tekin
+        - Mehmet Gökay Yıldız
         - Ecenur Sezer
   - type: input
     id: review-deadline

--- a/.github/ISSUE_TEMPLATE/group_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/group_issue_template.yml
@@ -1,6 +1,7 @@
 name: Group Issue Template
 description: This template is created to specifically use for the issues whose actions that are performed by more than 2 or more people.
-labels: status-new,priority-medium
+assignees: ['bahricanyesil']
+labels: [status-new,priority-medium]
 body:
   - type: markdown
     attributes:
@@ -48,7 +49,6 @@ body:
         - label: Onur Kömürcü
         - label: Mehmet Batuhan Çelik
         - label: Hasan Can Erol
-        - label: Ahmet Yiğit Özdoğan
         - label: Ecenur Sezer
         - label: Koray Tekin
         - label: Mehmet Gökay Yıldız

--- a/.github/ISSUE_TEMPLATE/research_template.yml
+++ b/.github/ISSUE_TEMPLATE/research_template.yml
@@ -1,6 +1,7 @@
 name: Research Template
 description: This template is created to specifically use for research issues.
-labels: status-new,priority-medium,type-research,type-documentation
+assignees: ['bahricanyesil']
+labels: [status-new,priority-medium,type-research,type-documentation]
 body:
   - type: markdown
     attributes:
@@ -40,7 +41,8 @@ body:
         - label: Onur Kömürcü
         - label: Mehmet Batuhan Çelik
         - label: Hasan Can Erol
-        - label: Ahmet Yiğit Özdoğan
+        - label: Koray Tekin
+        - label: Mehmet Gökay Yıldız
         - label: Ecenur Sezer
   - type: input
     id: deadline

--- a/README.md
+++ b/README.md
@@ -3,34 +3,34 @@
 We are a group of 11 people who are taking CMPE 352 -CMPE 451 courses at Boğaziçi University. Please visit our [Wiki](https://github.com/bounswe/bounswe2022group2/wiki) page to reach out our meeting notes, personal wiki pages of our members and other important informations about our group.
 
 # 🎓 Group Members
+
 * [Altay Acar (Communicator)](https://github.com/xltvy)
 * [Egemen Atik](https://github.com/egemenatikk)
 * [Ezgi Aysel Batı](https://github.com/ezgy)
 * [Mehmet Batuhan Çelik](https://github.com/mbatuhancelik)
 * [Hasan Can Erol](https://github.com/hasancan-code)
 * [Onur Kömürcü](https://github.com/onurkomurcu)
-* ~[Ahmet Yiğit Özdoğan](https://github.com/ahmet633)~
 * [Ecenur Sezer](https://github.com/codingAku)
 * [Muhammed Enes Sürmeli](https://github.com/surmelienes1)
 * [Bahrican Yeşil](https://github.com/bahricanyesil)
 * [Koray Tekin](https://github.com/Koraytkn)
-* [Gökay Yıldız](https://github.com/gokayyildiz)
+* [Mehmet Gökay Yıldız](https://github.com/gokayyildiz)
+* ~~[Ahmet Yiğit Özdoğan](https://github.com/ahmet633)~~
 
 # ❓ What should our members do?
 
-* ### Attending weekly meetings 
+* ### Attending weekly meetings
+
     All members are expected to attend the weekly meetings and participate in discussions. For when the weekly meetings occur, please refer to our [Communication Plan](https://github.com/bounswe/bounswe2022group2/wiki/Communication-Plan).
 
 * ### Learning weekly tasks
+
     Weekly tasks are being assigned in our meetings. These tasks can be checked from our meeting notes or our Discord channel if needed.
-    
+
 * ### Creating issues for tasks
+
     Every member should create corresponding issues for their given tasks. If a task is required to have more than 1 person to work on, then a "super" issue should be created and a checklist should be added in it for tracking the progress. Then, a reviewer should review and close the issue when the task is completed.
-    
+
 * ### Adding weekly efforts to personal wiki pages
-     At the end of every week, every member should add their weekly efforts to their personal wiki pages.    
 
-
-
-
-
+     At the end of every week, every member should add their weekly efforts to their personal wiki pages.


### PR DESCRIPTION
We have new team members and an old member who left the team. Therefore, we need to update our issue diagrams accordingly to match the reviewer and other options with the current team members. I also have some enhancements in the issue templates. You can see all details and all performed actions below:
- [x] Add "Koray Tekin" and "Mehmet Gökay Yıldız" names to all issue templates for reviewer and checkbox options (generic, group, and research templates)
- [x] Remove "Ahmet Yiğit Özdoğan" name from all options
- [x] Fix yml syntax errors for label list
- [x] Disable blank issues
- [x] Add a link for our wiki page
- [x] Add a default assignee to avoid unassigned issues

Closes #338 