### PR TITLE
Dockerization of Frontend

### DIFF
--- a/learnify/docker-compose.yml
+++ b/learnify/docker-compose.yml
@@ -24,6 +24,15 @@ services:
       - mongo_net
     depends_on:
       - mongodb
+  frontend:
+    hostname: frontend
+    build:
+      context: ./web
+      dockerfile: dockerfile
+    ports:
+      - "9000:3000"
+    depends_on:
+      - server
 
 networks:
   mongo_net:

--- a/learnify/web/.dockerignore
+++ b/learnify/web/.dockerignore
@@ -1,0 +1,11 @@
+# Items that don't need to be in a Docker image.
+# Anything not used by the build system should go here.
+Dockerfile
+.dockerignore
+.gitignore
+README.md
+
+# Artifacts that will be built during image creation.
+# This should contain all files created during `npm run build`.
+build
+node_modules

--- a/learnify/web/dockerfile
+++ b/learnify/web/dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile
+
+# ==== CONFIGURE =====
+# Use a Node 16 base image
+FROM node:18-alpine 
+# Set the working directory to /app inside the container
+WORKDIR /app
+# Optimization
+COPY ./package.json .
+RUN npm i
+# ==== BUILD =====
+# Install dependencies (npm ci makes sure the exact versions in the lockfile gets installed)
+RUN npm ci 
+# Copy app files
+COPY . .
+# Build the app
+RUN npm run build
+# ==== RUN =======
+# Set the env to "production"
+ENV NODE_ENV production
+# Expose the port on which the app will be running (3000 is the default that `serve` uses)
+EXPOSE 3000
+# Start the app
+CMD [ "npm", "start"]


### PR DESCRIPTION
As mentioned in the issue #412 I have implemented the dockerization related code for the frontend of the project, namely dockerfile and .dockerignore files in our web directory and the necessary updates on the docker-compose.yaml file.

You can go to the web directory and run below command to build, (re)create, start, and attach to containers:
`docker compose up`

It uses the latest build's configurations, and since our project is currently under development, running below command will be a better usage (it builds the latest code):
`docker compose up --build`