### PR TITLE
Mobile: forget password backend 384

### DIFF
--- a/learnify/mobile/lib/features/auth/forget-password/model/send_verification_request_model.dart
+++ b/learnify/mobile/lib/features/auth/forget-password/model/send_verification_request_model.dart
@@ -1,0 +1,21 @@
+import '../../../../core/base/model/base_model.dart';
+
+class SendVerificationRequest extends BaseModel<SendVerificationRequest> {
+  const SendVerificationRequest({this.email});
+
+  factory SendVerificationRequest.fromJson(Map<String, dynamic> json) =>
+      SendVerificationRequest(
+          email: BaseModel.getByType<String>(json['email']));
+
+  final String? email;
+
+  @override
+  SendVerificationRequest fromJson(Map<String, dynamic> json) =>
+      SendVerificationRequest.fromJson(json);
+
+  @override
+  Map<String, dynamic> get toJson => <String, dynamic>{'email': email};
+
+  @override
+  List<Object?> get props => <Object?>[email];
+}

--- a/learnify/mobile/lib/features/auth/forget-password/view-model/forget_password_view_model.dart
+++ b/learnify/mobile/lib/features/auth/forget-password/view-model/forget_password_view_model.dart
@@ -2,8 +2,17 @@ import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../core/base/view-model/base_view_model.dart';
+import '../../../../core/managers/network/models/l_response_model.dart';
+import '../../../../core/managers/network/models/message_response.dart';
+import '../../../../product/constants/navigation_constants.dart';
+import '../../../../product/constants/storage_keys.dart';
+import '../../service/auth_service.dart';
+import '../../service/l_auth_service.dart';
+import '../model/send_verification_request_model.dart';
 
 class ForgetPasswordViewModel extends BaseViewModel {
+  late final IAuthService _authService;
+
   late TextEditingController _emailController;
 
   TextEditingController get emailController => _emailController;
@@ -15,7 +24,9 @@ class ForgetPasswordViewModel extends BaseViewModel {
   bool get canVerify => _canVerify;
 
   @override
-  void initViewModel() {}
+  void initViewModel() {
+    _authService = AuthService.instance;
+  }
 
   @override
   void initView() {
@@ -49,7 +60,18 @@ class ForgetPasswordViewModel extends BaseViewModel {
 
   Future<String?> _forgetPasswordRequest() async {
     final bool isValid = formKey.currentState?.validate() ?? false;
-    if (isValid) {}
+    if (isValid) {
+      final SendVerificationRequest requestModel =
+          SendVerificationRequest(email: _emailController.text);
+
+      final IResponseModel<MessageResponse> resp =
+          await _authService.sendVerification(requestModel);
+      if (resp.hasError) return resp.error?.errorMessage;
+      await localManager.setString(StorageKeys.email, _emailController.text);
+      await navigationManager.navigateToPage(
+          path: NavigationConstants.verify,
+          data: <String, dynamic>{'email': _emailController.text});
+    }
     return null;
   }
 

--- a/learnify/mobile/lib/features/auth/forget-password/view/components/email_form.dart
+++ b/learnify/mobile/lib/features/auth/forget-password/view/components/email_form.dart
@@ -16,7 +16,6 @@ class _EmailForm extends StatelessWidget {
           labelText: TextKeys.emailLabel,
           prefixIcon: Icons.email_outlined,
           validator: Validators.email,
-          textInputAction: TextInputAction.next,
           autofillHints: const <String>[AutofillHints.email],
           textInputType: TextInputType.emailAddress,
         ));

--- a/learnify/mobile/lib/features/auth/service/auth_service.dart
+++ b/learnify/mobile/lib/features/auth/service/auth_service.dart
@@ -1,6 +1,7 @@
 import '../../../../core/managers/network/models/l_response_model.dart';
 import '../../../core/constants/enums/request_types.dart';
 import '../../../core/managers/network/models/message_response.dart';
+import '../forget-password/model/send_verification_request_model.dart';
 import '../signup/model/signup_request_model.dart';
 import 'l_auth_service.dart';
 
@@ -16,6 +17,7 @@ class AuthService extends IAuthService {
   static AuthService get instance => _instance;
 
   static const String _signup = '/auth/signup';
+  static const String _resend = '/auth/resend';
 
   @override
   Future<IResponseModel<MessageResponse>> signup(SignupRequest body) async =>
@@ -26,4 +28,13 @@ class AuthService extends IAuthService {
         body: body,
         requireAuth: false,
       );
+
+  @override
+  Future<IResponseModel<MessageResponse>> sendVerification(
+          SendVerificationRequest body) async =>
+      networkManager.send<SendVerificationRequest, MessageResponse>(_resend,
+          parseModel: const MessageResponse(),
+          type: RequestTypes.post,
+          body: body,
+          requireAuth: false);
 }

--- a/learnify/mobile/lib/features/auth/service/l_auth_service.dart
+++ b/learnify/mobile/lib/features/auth/service/l_auth_service.dart
@@ -1,10 +1,15 @@
 import '../../../core/base/service/base_service.dart';
 import '../../../core/managers/network/models/l_response_model.dart';
 import '../../../core/managers/network/models/message_response.dart';
+import '../forget-password/model/send_verification_request_model.dart';
 import '../signup/model/signup_request_model.dart';
 
 /// Abstract base class for auth service, defines the required functions.
 abstract class IAuthService extends BaseService {
   /// Sign ups the user.
   Future<IResponseModel<MessageResponse>> signup(SignupRequest body);
+
+  /// Sends verification code to email
+  Future<IResponseModel<MessageResponse>> sendVerification(
+      SendVerificationRequest body);
 }


### PR DESCRIPTION
As #384 explains, this pr responds to connecting  "Send Verification Code" button of the _Forget Password_ screen on the mobile app with the corresponding backend endpoint. 
-When a valid email is entered, app navigates to enter verification screen and a mail is sent via backend.
-When an invalid email is entered, a message for "enter a valid email" is displayed under the email field.
- When an input with valid email syntax (that does not exist) is entered, error message is displayed in a pop up.

Closes #384 