### PR TITLE
Mobile: Fix Selected Categories Issue Between Page Transitions

### DIFF
--- a/learnify/mobile/lib/features/learning-space/view-model/create_learning_space_view_model.dart
+++ b/learnify/mobile/lib/features/learning-space/view-model/create_learning_space_view_model.dart
@@ -87,6 +87,7 @@ class CreateLearningSpaceViewModel extends BaseViewModel {
     _titleController.dispose();
     _descriptionController.dispose();
     _participantsController.dispose();
+    _selectedCategories = <String>[];
     _setDefault();
     super.disposeView();
   }
@@ -111,6 +112,8 @@ class CreateLearningSpaceViewModel extends BaseViewModel {
     operation =
         CancelableOperation<String?>.fromFuture(_createLearningSpaceRequest());
     final String? res = await operation?.valueOrCancellation();
+    _canUpdate = false;
+    notifyListeners();
     return res;
   }
 
@@ -119,6 +122,8 @@ class CreateLearningSpaceViewModel extends BaseViewModel {
     operation =
         CancelableOperation<String?>.fromFuture(_editLearningSpaceRequest());
     final String? res = await operation?.valueOrCancellation();
+    _canUpdate = false;
+    notifyListeners();
     return res;
   }
 
@@ -155,6 +160,7 @@ class CreateLearningSpaceViewModel extends BaseViewModel {
     final List<String> newSelectedCategories =
         List<String>.from(_selectedCategories)..add(cName);
     _selectedCategories = newSelectedCategories;
+    _canUpdate = true;
     notifyListeners();
   }
 
@@ -165,6 +171,7 @@ class CreateLearningSpaceViewModel extends BaseViewModel {
     final List<String> newSelectedCategories =
         List<String>.from(_selectedCategories)..remove(cName);
     _selectedCategories = newSelectedCategories;
+    _canUpdate = true;
     notifyListeners();
   }
 }

--- a/learnify/mobile/lib/features/learning-space/view/components/create/learning_space_form.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/create/learning_space_form.dart
@@ -61,30 +61,22 @@ class _LearningSpaceForm extends StatelessWidget {
       child: Wrap(
         children: <Widget>[
           const Padding(padding: EdgeInsets.symmetric(horizontal: 20)),
-          const BaseText(
-            TextKeys.categories,
-            textAlign: TextAlign.left,
-          ),
+          const BaseText(TextKeys.categories, textAlign: TextAlign.left),
           const Padding(padding: EdgeInsets.symmetric(vertical: 5)),
-          SelectorHelper<List<String>, CreateLearningSpaceViewModel>().builder(
-            (_, CreateLearningSpaceViewModel model) =>
-                model.selectedCategoryNames,
-            (BuildContext context, List<String> tagList, _) => Wrap(
-                runSpacing: 5,
-                spacing: 5,
-                children: tagList
-                    .map((String tag) => Chip(
-                          label: Text(tag),
-                          labelPadding: EdgeInsets.zero,
-                          materialTapTargetSize:
-                              MaterialTapTargetSize.shrinkWrap,
-                          labelStyle: const TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: Colors.white,
-                              fontSize: 12),
-                          backgroundColor: context.primary,
-                        ))
-                    .toList()),
+          Padding(
+            padding: EdgeInsets.symmetric(
+                horizontal: context.width * 3, vertical: context.height),
+            child: SelectorHelper<List<String>, CreateLearningSpaceViewModel>()
+                .builder(
+              (_, CreateLearningSpaceViewModel model) =>
+                  model.selectedCategoryNames,
+              (BuildContext context, List<String> tagList, _) => Wrap(
+                  runSpacing: 5,
+                  spacing: 5,
+                  children: tagList
+                      .map((String tag) => CustomizedChip(tag: tag))
+                      .toList()),
+            ),
           )
         ],
       ));

--- a/learnify/mobile/lib/features/learning-space/view/create_learning_space_screen.dart
+++ b/learnify/mobile/lib/features/learning-space/view/create_learning_space_screen.dart
@@ -15,6 +15,7 @@ import '../../../product/language/language_keys.dart';
 import '../constants/widget_keys.dart';
 import '../models/learning_space_model.dart';
 import '../view-model/create_learning_space_view_model.dart';
+import 'learning_space_detail_screen.dart';
 
 part './components/create/add_categories.dart';
 part './components/create/learning_space_form.dart';

--- a/learnify/mobile/lib/features/learning-space/view/learning_space_detail_screen.dart
+++ b/learnify/mobile/lib/features/learning-space/view/learning_space_detail_screen.dart
@@ -92,19 +92,7 @@ class LearningSpaceDetailScreen extends BaseView<LearningSpaceViewModel>
   static Widget _tagWidget(BuildContext context, List<String> tagList) => Wrap(
       runSpacing: 5,
       spacing: 5,
-      children: tagList
-          .map((String tag) => Chip(
-                label: Text(tag),
-                labelPadding: EdgeInsets.symmetric(
-                    horizontal: context.responsiveSize * 1.4),
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                labelStyle: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
-                    fontSize: 12),
-                backgroundColor: context.primary,
-              ))
-          .toList());
+      children: tagList.map((String tag) => CustomizedChip(tag: tag)).toList());
 }
 
 class MySliverOverlayAbsorber extends StatefulWidget {
@@ -122,6 +110,7 @@ class _MySliverOverlayAbsorberState extends State<MySliverOverlayAbsorber> {
   Widget build(BuildContext context) => SliverOverlapAbsorber(
         handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
         sliver: SliverAppBar(
+          iconTheme: const IconThemeData(color: Colors.white),
           flexibleSpace: FlexibleSpaceBar(
             centerTitle: true,
             background: Column(
@@ -229,5 +218,21 @@ class ColoredTabBar extends Container implements PreferredSizeWidget {
   Widget build(BuildContext context) => ColoredBox(
         color: color,
         child: tabBar,
+      );
+}
+
+class CustomizedChip extends StatelessWidget {
+  const CustomizedChip({required this.tag, Key? key}) : super(key: key);
+  final String tag;
+
+  @override
+  Widget build(BuildContext context) => Chip(
+        label: Text(tag),
+        labelPadding:
+            EdgeInsets.symmetric(horizontal: context.responsiveSize * 1.4),
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        labelStyle: const TextStyle(
+            fontWeight: FontWeight.bold, color: Colors.white, fontSize: 12),
+        backgroundColor: context.primary,
       );
 }

--- a/learnify/mobile/lib/features/view-learning-spaces/view/view_all_screen.dart
+++ b/learnify/mobile/lib/features/view-learning-spaces/view/view_all_screen.dart
@@ -3,11 +3,9 @@ import 'package:flutter/material.dart';
 import '../../../core/base/view/base_view.dart';
 import '../../../core/extensions/context/context_extensions.dart';
 import '../../../core/extensions/context/theme_extensions.dart';
-import '../../../core/managers/navigation/navigation_manager.dart';
 import '../../../core/widgets/app-bar/default_app_bar.dart';
 import '../../../core/widgets/buttons/base_icon_button.dart';
 import '../../../core/widgets/text/base_text.dart';
-import '../../../product/constants/navigation_constants.dart';
 import '../../home/model/learning_space_model.dart';
 import '../../home/view-model/home_view_model.dart';
 import 'view_all_list.dart';
@@ -36,12 +34,9 @@ class ViewAllScreen extends BaseView<HomeViewModel> {
         size: context.height * 6,
         color: context.lightActiveColor,
         actionsList: <Widget>[
-          Padding(
-            padding: EdgeInsets.all(context.responsiveSize * .6),
-          ),
+          Padding(padding: EdgeInsets.all(context.responsiveSize * .6)),
           BaseIconButton(
-            onPressed: () async => NavigationManager.instance
-                .navigateToPageClear(path: NavigationConstants.home),
+            onPressed: () => Navigator.of(context).pop(),
             icon: Icons.arrow_back_outlined,
             color: context.lightActiveColor,
           ),


### PR DESCRIPTION
## Short Description

This will mainly fix the bugs on the create learning space screen. The categories are not cleared on page changes.

------

## What Does This PR Include?

1. Clear the selected category list on page transitions
2. Design improvements in the create learning space screen
3. Create a generic customized chip widget to use across the app
