### PR TITLE
Integrate display logic for image annotations

### DIFF
--- a/learnify/mobile/lib/core/constants/main_type_definitions.dart
+++ b/learnify/mobile/lib/core/constants/main_type_definitions.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../features/learning-space/models/annotation_model.dart';
 import '../widgets/app-bar/default_app_bar.dart';
 
 /// FutureOr<void> function definition.
@@ -30,14 +31,14 @@ typedef StringCallback = void Function(String id);
 typedef AnnotationClickCallback = void Function(
     String id, String annotatedText);
 
-typedef AnnotateTextDialogCallback = Future<String?> Function(
+typedef AnnotateTextDialogCallback = Future<Annotation?> Function(
     int startIndex, int endIndex, String annotation, String? chapterId);
-typedef AnnotateImageDialogCallback = Future<String?> Function(
+typedef AnnotateImageDialogCallback = Future<Annotation?> Function(
     Offset startOffset,
     Offset endOffset,
     String annotation,
     String? chapterId,
     Color color,
     String imageUrl);
-typedef AnnotateImageCallback = Future<bool> Function(
+typedef AnnotateImageCallback = Future<Annotation?> Function(
     Offset start, Offset end, Color color);

--- a/learnify/mobile/lib/core/widgets/dialog/dialog_builder.dart
+++ b/learnify/mobile/lib/core/widgets/dialog/dialog_builder.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../features/learning-space/models/annotation_model.dart';
 import '../../../product/language/language_keys.dart';
 import '../../../product/theme/general_theme.dart';
 import '../../constants/main_type_definitions.dart';
@@ -55,7 +56,7 @@ class DialogBuilder {
       );
 
   /// Annotate dialog
-  Future<bool?> annotateDialog(
+  Future<Annotation?> annotateDialog(
     String? chapterId, {
     AnnotateTextDialogCallback? textCallback,
     AnnotateImageDialogCallback? imageCallback,
@@ -67,7 +68,7 @@ class DialogBuilder {
     String? imageUrl,
   }) async {
     String annotationText = '';
-    final bool? res = await showDialog(
+    final Annotation? res = await showDialog(
       context: context,
       // barrierDismissible: false,
       builder: (BuildContext context) => StatefulBuilder(
@@ -99,16 +100,20 @@ class DialogBuilder {
           actions: <Widget>[
             _dialogActionButton(
               TextKeys.cancel,
-              callback: () => Navigator.of(context).pop(false),
+              callback: () => Navigator.of(context).pop(null),
             ),
             _dialogActionButton(
               TextKeys.annotate,
               asyncCallback: () async {
+                final NavigatorState navigator = Navigator.of(context);
+
                 if (textCallback != null) {
-                  await textCallback(startIndex ?? 0, endIndex ?? 0,
-                      annotationText, chapterId);
+                  final Annotation? a = await textCallback(startIndex ?? 0,
+                      endIndex ?? 0, annotationText, chapterId);
+                  navigator.pop(a);
+                  return null;
                 } else if (imageCallback != null && imageUrl != null) {
-                  await imageCallback(
+                  final Annotation? a = await imageCallback(
                     startOffset ?? Offset.zero,
                     endOffset ?? Offset.zero,
                     annotationText,
@@ -116,7 +121,10 @@ class DialogBuilder {
                     color ?? Colors.white,
                     imageUrl,
                   );
+                  navigator.pop(a);
+                  return null;
                 }
+                navigator.pop(null);
                 return null;
               },
               isAction: true,
@@ -139,10 +147,8 @@ class DialogBuilder {
       isAction
           ? ActionButton(
               onPressedError: () async {
-                final NavigatorState navigator = Navigator.of(context);
                 final String? res =
                     asyncCallback == null ? null : await asyncCallback();
-                navigator.pop(res == null);
                 return res;
               },
               isActive: isActive,

--- a/learnify/mobile/lib/core/widgets/image/image_painter.dart
+++ b/learnify/mobile/lib/core/widgets/image/image_painter.dart
@@ -9,6 +9,8 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart' hide Image;
 
+import '../../../features/learning-space/models/annotation_model.dart';
+
 ///Handles all the painting ongoing on the canvas.
 class DrawImage extends CustomPainter {
   ///Constructor for the canvas
@@ -102,7 +104,11 @@ enum PaintMode {
 class PaintInfo {
   ///In case of string, it is used to save string value entered.
   PaintInfo(
-      {required this.offset, required this.painter, this.text, this.mode});
+      {required this.offset,
+      required this.painter,
+      this.text,
+      this.mode,
+      required this.annotation});
 
   ///Mode of the paint method.
   PaintMode? mode;
@@ -116,6 +122,8 @@ class PaintInfo {
 
   ///Used to save text in case of text type.
   String? text;
+
+  Annotation annotation;
 }
 
 @immutable

--- a/learnify/mobile/lib/features/learning-space/view-model/learning_space_view_model.dart
+++ b/learnify/mobile/lib/features/learning-space/view-model/learning_space_view_model.dart
@@ -70,33 +70,32 @@ class LearningSpaceViewModel extends BaseViewModel {
     return null;
   }
 
-  Future<String?> annotateText(int startIndex, int endIndex, String annotation,
-      String? chapterId) async {
+  Future<Annotation?> annotateText(int startIndex, int endIndex,
+      String annotation, String? chapterId) async {
     final int itemIndex = _chapters.indexWhere(
         (Chapter c) => c.id?.compareWithoutCase(chapterId) ?? false);
-    if (itemIndex == -1) return 'Chapter not found';
+    if (itemIndex == -1) return null;
     final Chapter oldChapter = _chapters[itemIndex];
+    final Annotation newAnnotation = Annotation(
+      id: (startIndex * endIndex + Random().nextInt(490)).toString(),
+      content: annotation,
+      startIndex: startIndex,
+      endIndex: endIndex,
+      chapterId: oldChapter.id,
+      courseId: oldChapter.courseId,
+    );
     final List<Annotation> newAnnotations =
         List<Annotation>.from(oldChapter.annotations)
-          ..add(
-            Annotation(
-              id: (startIndex * endIndex + Random().nextInt(490)).toString(),
-              content: annotation,
-              startIndex: startIndex,
-              endIndex: endIndex,
-              chapterId: oldChapter.id,
-              courseId: oldChapter.courseId,
-            ),
-          )
+          ..add(newAnnotation)
           ..sort((Annotation a1, Annotation a2) =>
               a1.startIndex.compareTo(a2.startIndex));
     _chapters[itemIndex] =
         _chapters[itemIndex].copyWith(annotations: newAnnotations);
     notifyListeners();
-    return null;
+    return newAnnotation;
   }
 
-  Future<String?> annotateImage(
+  Future<Annotation?> annotateImage(
       Offset startOffset,
       Offset endOffset,
       String annotation,
@@ -105,29 +104,27 @@ class LearningSpaceViewModel extends BaseViewModel {
       String? imageUrl) async {
     final int itemIndex = _chapters.indexWhere(
         (Chapter c) => c.id?.compareWithoutCase(chapterId) ?? false);
-    if (itemIndex == -1) return 'Chapter not found';
+    if (itemIndex == -1) return null;
     final Chapter oldChapter = _chapters[itemIndex];
+    final Annotation newAnnotation = Annotation(
+      id: (startOffset.dx * endOffset.dx + Random().nextInt(490)).toString(),
+      content: annotation,
+      startOffset: startOffset,
+      endOffset: endOffset,
+      chapterId: oldChapter.id,
+      courseId: oldChapter.courseId,
+      isImage: true,
+      colorParam: color,
+      imageUrl: imageUrl,
+    );
     final List<Annotation> newAnnotations =
         List<Annotation>.from(oldChapter.annotations)
-          ..add(
-            Annotation(
-              id: (startOffset.dx * endOffset.dx + Random().nextInt(490))
-                  .toString(),
-              content: annotation,
-              startOffset: startOffset,
-              endOffset: endOffset,
-              chapterId: oldChapter.id,
-              courseId: oldChapter.courseId,
-              isImage: true,
-              colorParam: color,
-              imageUrl: imageUrl,
-            ),
-          )
+          ..add(newAnnotation)
           ..sort((Annotation a1, Annotation a2) =>
               a1.startIndex.compareTo(a2.startIndex));
     _chapters[itemIndex] =
         _chapters[itemIndex].copyWith(annotations: newAnnotations);
     notifyListeners();
-    return null;
+    return newAnnotation;
   }
 }

--- a/learnify/mobile/lib/features/learning-space/view/components/chapter/chapter_item.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/chapter/chapter_item.dart
@@ -118,7 +118,7 @@ class ChapterItem extends StatelessWidget {
           child: AnnotatableImage.network(
             images[i],
             annotateCallback: (Offset start, Offset end, Color color) async =>
-                false,
+                null,
             scalable: false,
             initialColor: context.primary,
             initialPaintMode: PaintMode.none,
@@ -126,6 +126,7 @@ class ChapterItem extends StatelessWidget {
                 List<PaintInfo>.generate(imageAnnotations.length, (int i) {
               final Annotation a = imageAnnotations[i];
               return PaintInfo(
+                annotation: a,
                 offset: <Offset>[a.startOffset, a.endOffset],
                 painter: Paint()
                   ..color = a.color

--- a/learnify/mobile/lib/features/learning-space/view/components/chapter_image.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/chapter_image.dart
@@ -39,12 +39,14 @@ class ChapterImage extends StatelessWidget {
         child: AnnotatableImage.network(
           imageUrl,
           scalable: false,
+          clickable: true,
           initialColor: context.primary,
           initialPaintMode: PaintMode.rect,
           paintHistory:
               List<PaintInfo>.generate(imageAnnotations.length, (int i) {
             final Annotation a = imageAnnotations[i];
             return PaintInfo(
+              annotation: a,
               offset: <Offset>[a.startOffset, a.endOffset],
               painter: Paint()
                 ..color = a.color
@@ -53,16 +55,14 @@ class ChapterImage extends StatelessWidget {
             );
           }),
           annotateCallback: (Offset start, Offset end, Color color) async =>
-              await DialogBuilder(context).annotateDialog(
-                chapterId,
-                imageCallback:
-                    context.read<LearningSpaceViewModel>().annotateImage,
-                startOffset: start,
-                endOffset: end,
-                color: color,
-                imageUrl: imageUrl,
-              ) ??
-              false,
+              DialogBuilder(context).annotateDialog(
+            chapterId,
+            imageCallback: context.read<LearningSpaceViewModel>().annotateImage,
+            startOffset: start,
+            endOffset: end,
+            color: color,
+            imageUrl: imageUrl,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Short Description

We have already implemented image annotations with PR #581. However, we should also implement a way/detect these annotations on images. We should capture the gesture of the user with a detector, find the position and show all annotations that contain the touch point. This PR will do the all required things for displaying image annotations.

------

## What Does This PR Include?

1. Modify the annotation type definitions to return Annotation model
2. Integrate this change and also return Annotation model from the annotate dialog
3. Add annotation info paint info class
4. Added conditional gesture detector into the annotatable image widget
5. Implemented ontapdown function and found the annotation rectangles which contain the selected point
6. Opened the annotation dialog with the contents of the found annotations

------

Closes #579 
