### PR TITLE
615 getters for learningspaces: get most participated learning spaces if a query is not given

### DIFF
--- a/learnify/backend/api/controllers/learning_space/semantic_search_learning_space.js
+++ b/learnify/backend/api/controllers/learning_space/semantic_search_learning_space.js
@@ -34,7 +34,7 @@ export default async (req, res) => {
             return res.status(500).json({ "resultMessage": "Could not find returned learning spaces in the DB" });
           });
 
-          ls = ls.slice(0,2);
+          ls = ls.slice(0,10);
 
     }
 

--- a/learnify/backend/api/controllers/learning_space/semantic_search_learning_space.js
+++ b/learnify/backend/api/controllers/learning_space/semantic_search_learning_space.js
@@ -4,17 +4,39 @@ import { LearningSpace } from '../../../models/index.js';
 import { semantic_server } from "../../../config/index.js";
 export default async (req, res) => {
 
-    if(!("query" in req.query)){
-        return res.status(400).json({"resultMessage": "Please enter your query string."})
-    }
-    var response = await axios.get(semantic_server + "/search/" + req.query.query);
+    var ls;
+    if(("query" in req.query)){
+        var response = await axios.get(semantic_server + "/search/" + req.query.query);
+        
+        var titles = response.data.titles;
     
-    var titles = response.data.titles;
+        ls = await LearningSpace.find({"title" : titles}).catch((err) =>{
+            console.log(err.message)
+            return res.status(500).json({ "resultMessage": "Could not find returned learning spaces in the DB" });
+          });
+    }else{
+        ls = await LearningSpace.aggregate([
+            { 
+                "$match": {}
+            },
+            {
+                "$sort": {
+                    "Learningspace.num_participants": 1
+                }
+            },
+            {
+                "$unset": "BERT"
+                
+            }
+        ]
+        ).catch((err) =>{
+            console.log(err.message)
+            return res.status(500).json({ "resultMessage": "Could not find returned learning spaces in the DB" });
+          });
 
-    var ls = await LearningSpace.find({"title" : titles}).catch((err) =>{
-        console.log(err.message)
-        return res.status(500).json({ "resultMessage": "Could not find returned learning spaces in the DB" });
-      });
+          ls = ls.slice(0,2);
+
+    }
 
     return res.status(200).json({learning_spaces : ls})
 


### PR DESCRIPTION
This PR edits GET /learningspace so that if a query is not given, the endpoint returns the most participated learning spaces.
This feature will be used so that most participated LS can be shown in the main page.

In future, we need to customize these learning space suggestions.
