### PR TITLE
Frontend: HOTFIX Learning Space Page Structural Overflow

### DIFF
--- a/learnify/web/src/pages/LearningSpace.js
+++ b/learnify/web/src/pages/LearningSpace.js
@@ -67,6 +67,7 @@ function LearningSpace() {
                     <button className="btn-orange" data-testid="forgotPassword">JOIN</button>
                     <div className='space-8'></div>
                     <a><img src={elipse} alt="elipse" height={360} /></a>
+                    <div className='space-8'></div>
                 </div>
                 
             </div>

--- a/learnify/web/src/pages/style.css
+++ b/learnify/web/src/pages/style.css
@@ -651,9 +651,9 @@ h1 {
   }
 
 .learning-space {
-    height: 100vh;
     display: flex;
     color: #FFF7E9;
+    min-height: calc(100vh - 190px);
 }
 
 .ls-content {


### PR DESCRIPTION
## PR Description:
In the learning space page illustration and the middle component was overflowing on the footer component. I have fixed the issue by editing css class and adding a space div inbetween.

***
## Notes:
* We use the structure of `<NavBar/><Body/><Footer/>` in our pages. In the css class of the Body we need to add `min-height: calc(100vh - 190px);` so that no overflow can be seen in the Body.
***
## Routine Check
- [x] I have fetched and pulled the latest version of the parent branch.
- [x] This PR does not have any conflicts with the parent branch.
***
## Corresponding Issue
Closes #636 
