### PR TITLE
Mobile: Map integration into the Event Item

### DIFF
--- a/learnify/mobile/android/app/src/main/AndroidManifest.xml
+++ b/learnify/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.bounswe.learnify">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <application android:label="Learnify" android:name="${applicationName}" android:icon="@mipmap/ic_launcher">
         <activity android:name=".MainActivity" android:exported="true" android:launchMode="singleTop" android:theme="@style/LaunchTheme" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode" android:hardwareAccelerated="true" android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as

--- a/learnify/mobile/lib/core/managers/network/network_manager.dart
+++ b/learnify/mobile/lib/core/managers/network/network_manager.dart
@@ -42,7 +42,7 @@ class NetworkManager extends INetworkManager
 
   static final NetworkManager _instance = NetworkManager._init();
   // TODO: Fix
-  static const String _baseUrl = NetworkConstants.productionUrl;
+  static const String _baseUrl = NetworkConstants.localhostUrl;
 
   /// Returns the singleton instance of the network manager.
   static NetworkManager get instance => _instance;

--- a/learnify/mobile/lib/features/learning-space/models/event.dart
+++ b/learnify/mobile/lib/features/learning-space/models/event.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import '../../../../core/base/model/base_model.dart';
+import 'geolocation/geolocation_model.dart';
 
 class Event extends BaseModel<Event> {
   const Event({
@@ -11,8 +12,7 @@ class Event extends BaseModel<Event> {
     this.duration,
     this.participationLimit,
     this.eventCreator,
-    this.geoLocationLat,
-    this.geoLocationLon,
+    this.geoLocation,
     this.participants = const <String>[],
     this.lsId,
   });
@@ -26,8 +26,8 @@ class Event extends BaseModel<Event> {
         participationLimit:
             BaseModel.getByType<int>(json['participationLimit']),
         eventCreator: BaseModel.getByType<String>(json['eventCreator']),
-        geoLocationLat: BaseModel.getByType<double>(json['geoLocationLat']),
-        geoLocationLon: BaseModel.getByType<double>(json['geoLocationLon']),
+        geoLocation: BaseModel.embeddedModelFromJson<GeoLocation>(
+            json['geoLocation'], const GeoLocation()),
         participants: BaseModel.getWithDefault<List<String>>(
             json['participants'], <String>[]),
         lsId: BaseModel.getByType<String>(json['lsId']),
@@ -50,8 +50,7 @@ class Event extends BaseModel<Event> {
         participationLimit: Random().nextInt(50) + 50,
         duration: Random().nextInt(15) * 60,
         eventCreator: 'eventCreator',
-        geoLocationLat: 12,
-        geoLocationLon: 34,
+        geoLocation: GeoLocation.dummy(),
         participants: const <String>['adas', 'bdf', 'cas'],
       );
 
@@ -78,9 +77,8 @@ class Event extends BaseModel<Event> {
     int? duration,
     int? participationLimit,
     String? eventCreator,
-    double? geoLocationLat,
     String? title,
-    double? geoLocationLon,
+    GeoLocation? geoLocation,
     List<String>? participants,
     bool? isHappening,
     String? lsId,
@@ -95,8 +93,7 @@ class Event extends BaseModel<Event> {
         lsId: lsId ?? this.lsId,
         title: title ?? this.title,
         eventCreator: eventCreator ?? this.eventCreator,
-        geoLocationLat: geoLocationLat ?? this.geoLocationLat,
-        geoLocationLon: geoLocationLon ?? this.geoLocationLon,
+        geoLocation: geoLocation ?? this.geoLocation,
         participants: participants ?? this.participants,
       );
 
@@ -106,8 +103,7 @@ class Event extends BaseModel<Event> {
   final int? duration;
   final int? participationLimit;
   final String? eventCreator;
-  final double? geoLocationLat;
-  final double? geoLocationLon;
+  final GeoLocation? geoLocation;
   final List<String> participants;
   final String? lsId;
   final String? title;
@@ -123,9 +119,9 @@ class Event extends BaseModel<Event> {
         'duration': duration,
         'participationLimit': participationLimit,
         'eventCreator': eventCreator,
-        'geoLocationLat': geoLocationLat,
-        'geoLocationLon': geoLocationLon,
+        'geoLocation': geoLocation,
         'participants': participants,
+        'geoLocation': BaseModel.embeddedModelToJson<GeoLocation>(geoLocation),
         'lsId': lsId,
         'title': title,
       };
@@ -138,8 +134,7 @@ class Event extends BaseModel<Event> {
         duration,
         participationLimit,
         eventCreator,
-        geoLocationLat,
-        geoLocationLon,
+        geoLocation,
         participants,
         lsId,
         title

--- a/learnify/mobile/lib/features/learning-space/models/event.dart
+++ b/learnify/mobile/lib/features/learning-space/models/event.dart
@@ -14,9 +14,7 @@ class Event extends BaseModel<Event> {
     this.geoLocationLat,
     this.geoLocationLon,
     this.participants = const <String>[],
-    this.isHappening = false,
-    this.courseId,
-    this.isCompleted = false,
+    this.lsId,
   });
   factory Event.fromJson(Map<String, dynamic> json) => Event(
         id: BaseModel.getByType<String>(json['_id']) ??
@@ -32,14 +30,12 @@ class Event extends BaseModel<Event> {
         geoLocationLon: BaseModel.getByType<double>(json['geoLocationLon']),
         participants: BaseModel.getWithDefault<List<String>>(
             json['participants'], <String>[]),
-        isHappening: BaseModel.getWithDefault<bool>(json['isHappening'], false),
-        courseId: BaseModel.getByType<String>(json['courseId']),
-        isCompleted: BaseModel.getWithDefault<bool>(json['isCompleted'], false),
+        lsId: BaseModel.getByType<String>(json['lsId']),
       );
 
   factory Event.dummy(int? id) => Event(
         id: id.toString(),
-        courseId: id.toString(),
+        lsId: id.toString(),
         date: (id ?? 0) % 3 == 0
             ? DateTime.now().subtract(Duration(
                 days: Random().nextInt(20),
@@ -56,7 +52,7 @@ class Event extends BaseModel<Event> {
         eventCreator: 'eventCreator',
         geoLocationLat: 12,
         geoLocationLon: 34,
-        participants: const ['adas', 'bdf', 'cas'],
+        participants: const <String>['adas', 'bdf', 'cas'],
       );
 
   static const List<String> _eventTitles = <String>[
@@ -87,7 +83,7 @@ class Event extends BaseModel<Event> {
     double? geoLocationLon,
     List<String>? participants,
     bool? isHappening,
-    String? courseId,
+    String? lsId,
     bool? isCompleted,
   }) =>
       Event(
@@ -96,13 +92,11 @@ class Event extends BaseModel<Event> {
         description: description ?? this.description,
         participationLimit: participationLimit ?? this.participationLimit,
         duration: duration ?? this.duration,
-        courseId: courseId ?? this.courseId,
+        lsId: lsId ?? this.lsId,
         title: title ?? this.title,
         eventCreator: eventCreator ?? this.eventCreator,
         geoLocationLat: geoLocationLat ?? this.geoLocationLat,
         geoLocationLon: geoLocationLon ?? this.geoLocationLon,
-        isCompleted: isCompleted ?? this.isCompleted,
-        isHappening: isHappening ?? this.isHappening,
         participants: participants ?? this.participants,
       );
 
@@ -115,9 +109,7 @@ class Event extends BaseModel<Event> {
   final double? geoLocationLat;
   final double? geoLocationLon;
   final List<String> participants;
-  final bool isHappening;
-  final String? courseId;
-  final bool isCompleted;
+  final String? lsId;
   final String? title;
 
   @override
@@ -134,9 +126,7 @@ class Event extends BaseModel<Event> {
         'geoLocationLat': geoLocationLat,
         'geoLocationLon': geoLocationLon,
         'participants': participants,
-        'isHappening': isHappening,
-        'courseId': courseId,
-        'isCompleted': isCompleted,
+        'lsId': lsId,
         'title': title,
       };
 
@@ -151,9 +141,7 @@ class Event extends BaseModel<Event> {
         geoLocationLat,
         geoLocationLon,
         participants,
-        isHappening,
-        courseId,
-        isCompleted,
+        lsId,
         title
       ];
 }

--- a/learnify/mobile/lib/features/learning-space/models/geolocation/geolocation_model.dart
+++ b/learnify/mobile/lib/features/learning-space/models/geolocation/geolocation_model.dart
@@ -7,15 +7,15 @@ class GeoLocation extends BaseModel<GeoLocation> {
     this.accuracy = 0,
     this.altitude = 0,
     this.altitudeAccuracy = 0,
-    this.heading = 0,
+    this.heading = 0, 
     this.speed = 0,
     this.timestamp = 0,
   });
 
   factory GeoLocation.dummy({double? latitude, double? longitude}) =>
       GeoLocation(
-        latitude: latitude ?? 31.32,
-        longitude: longitude ?? 35.12,
+        latitude: latitude ?? 35.268259,
+        longitude: longitude ?? 33.824730,
         accuracy: 98,
         altitude: 2,
         altitudeAccuracy: 80,

--- a/learnify/mobile/lib/features/learning-space/models/geolocation/geolocation_model.dart
+++ b/learnify/mobile/lib/features/learning-space/models/geolocation/geolocation_model.dart
@@ -1,0 +1,89 @@
+import '../../../../../core/base/model/base_model.dart';
+
+class GeoLocation extends BaseModel<GeoLocation> {
+  const GeoLocation({
+    this.latitude = 0,
+    this.longitude = 0,
+    this.accuracy = 0,
+    this.altitude = 0,
+    this.altitudeAccuracy = 0,
+    this.heading = 0,
+    this.speed = 0,
+    this.timestamp = 0,
+  });
+
+  factory GeoLocation.dummy({double? latitude, double? longitude}) =>
+      GeoLocation(
+        latitude: latitude ?? 31.32,
+        longitude: longitude ?? 35.12,
+        accuracy: 98,
+        altitude: 2,
+        altitudeAccuracy: 80,
+        heading: 12,
+        speed: 13,
+        timestamp: 123123,
+      );
+
+  factory GeoLocation.fromJson(Map<String, dynamic> json) => GeoLocation(
+        latitude: BaseModel.getWithDefault<double>(json['latitude'], 0),
+        longitude: BaseModel.getWithDefault<double>(json['longitude'], 0),
+        accuracy: BaseModel.getWithDefault<double>(json['accuracy'], 0),
+        altitude: BaseModel.getWithDefault<double>(json['altitude'], 0),
+        altitudeAccuracy:
+            BaseModel.getWithDefault<double>(json['altitudeAccuracy'], 0),
+        heading: BaseModel.getWithDefault<double>(json['heading'], 0),
+        speed: BaseModel.getWithDefault<double>(json['speed'], 0),
+        timestamp: BaseModel.getWithDefault<double>(json['timestamp'], 0),
+      );
+
+  GeoLocation copyWith({
+    double? latitude,
+    double? longitude,
+    double? accuracy,
+    double? altitude,
+    double? altitudeAccuracy,
+    double? heading,
+    double? speed,
+    double? timestamp,
+  }) =>
+      GeoLocation(
+        latitude: latitude ?? this.latitude,
+        longitude: longitude ?? this.longitude,
+        accuracy: accuracy ?? this.accuracy,
+        altitude: altitude ?? this.altitude,
+        altitudeAccuracy: altitudeAccuracy ?? this.altitudeAccuracy,
+        heading: heading ?? this.heading,
+        speed: speed ?? this.speed,
+        timestamp: timestamp ?? this.timestamp,
+      );
+
+  final double latitude;
+  final double longitude;
+  final double accuracy;
+  final double altitude;
+  final double altitudeAccuracy;
+  final double heading;
+  final double speed;
+  final double timestamp;
+
+  @override
+  GeoLocation fromJson(Map<String, dynamic> json) => GeoLocation.fromJson(json);
+
+  @override
+  Map<String, dynamic> get toJson => <String, dynamic>{
+        'latitude': latitude,
+        'longitude': longitude,
+        'accuracy': accuracy,
+        'altitude': altitude,
+        'altitudeAccuracy': altitudeAccuracy,
+        'heading': heading,
+        'speed': speed,
+        'timestamp': timestamp,
+      };
+
+  @override
+  List<Object?> get props => <Object?>[
+        latitude,
+        longitude,
+      ];
+}

--- a/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
@@ -112,7 +112,8 @@ class EventItem extends StatelessWidget {
           padding: EdgeInsets.only(top: context.height * 1.8),
           child: SizedBox(
             height: context.height * 22,
-            child: _EventMap(location: GeoLocation.dummy()),
+            child:
+                _EventMap(location: event.geoLocation ?? const GeoLocation()),
           ),
         ),
         PostList.createEditButton(

--- a/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
@@ -97,13 +97,41 @@ class EventItem extends StatelessWidget {
         _infoText(
             context, TextKeys.eventDuration, '${event.duration?.minsToString}'),
         context.sizedH(.8),
-        _infoText(context, TextKeys.eventParticipants, '',
-            customWidget: _participantsRow(context, userPhotos),
-            lastChild: BaseText(
-              '${userPhotos.length}/${event.participationLimit}',
-              translated: false,
-              style: context.bodySmall,
-            )),
+        _infoText(
+          context,
+          TextKeys.eventParticipants,
+          '',
+          customWidget: _participantsRow(context, userPhotos),
+          lastChild: BaseText(
+            '${userPhotos.length}/${event.participationLimit}',
+            translated: false,
+            style: context.bodySmall,
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.only(top: context.height * 1),
+          child: SizedBox(
+            height: context.height * 20,
+            child: FlutterMap(
+              options: MapOptions(
+                center: LatLng(51.509364, -0.128928),
+                zoom: 9.2,
+              ),
+              nonRotatedChildren: [
+                AttributionWidget.defaultWidget(
+                  source: 'OpenStreetMap contributors',
+                  onSourceTapped: null,
+                ),
+              ],
+              children: [
+                TileLayer(
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  userAgentPackageName: 'com.example.app',
+                ),
+              ],
+            ),
+          ),
+        ),
         PostList.createEditButton(
             context,
             isPassed ? TextKeys.passedEvent : TextKeys.editEvent,

--- a/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
@@ -109,27 +109,10 @@ class EventItem extends StatelessWidget {
           ),
         ),
         Padding(
-          padding: EdgeInsets.only(top: context.height * 1),
+          padding: EdgeInsets.only(top: context.height * 1.8),
           child: SizedBox(
-            height: context.height * 20,
-            child: FlutterMap(
-              options: MapOptions(
-                center: LatLng(51.509364, -0.128928),
-                zoom: 9.2,
-              ),
-              nonRotatedChildren: [
-                AttributionWidget.defaultWidget(
-                  source: 'OpenStreetMap contributors',
-                  onSourceTapped: null,
-                ),
-              ],
-              children: [
-                TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  userAgentPackageName: 'com.example.app',
-                ),
-              ],
-            ),
+            height: context.height * 22,
+            child: _EventMap(location: GeoLocation.dummy()),
           ),
         ),
         PostList.createEditButton(

--- a/learnify/mobile/lib/features/learning-space/view/components/events/event_map.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/event_map.dart
@@ -10,14 +10,29 @@ class _EventMap extends StatefulWidget {
 
 class __EventMapState extends State<_EventMap> {
   @override
-  Widget build(BuildContext context) => FlutterMap(
-        options: MapOptions(
-            center: LatLng(35.269259, 33.825730), maxZoom: 19, zoom: 16),
-        children: <Widget>[
-          TileLayer(
-            urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-            userAgentPackageName: 'com.bounswe.learnify',
-          ),
-        ],
-      );
+  Widget build(BuildContext context) {
+    final LatLng centerPoint =
+        LatLng(widget.location.latitude, widget.location.longitude);
+    final LatLng markerPoint =
+        LatLng(widget.location.latitude, widget.location.longitude);
+    return FlutterMap(
+      options: MapOptions(center: centerPoint, maxZoom: 19),
+      children: <Widget>[
+        TileLayer(
+          urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+          userAgentPackageName: 'com.bounswe.learnify',
+        ),
+        MarkerLayer(
+          markers: <Marker>[
+            Marker(
+              width: context.width * 12,
+              height: context.width * 12,
+              point: markerPoint,
+              builder: (_) => Image.asset(IconKeys.logo),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
 }

--- a/learnify/mobile/lib/features/learning-space/view/components/events/event_map.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/event_map.dart
@@ -11,12 +11,10 @@ class _EventMap extends StatefulWidget {
 class __EventMapState extends State<_EventMap> {
   @override
   Widget build(BuildContext context) {
-    final LatLng centerPoint =
-        LatLng(widget.location.latitude, widget.location.longitude);
     final LatLng markerPoint =
         LatLng(widget.location.latitude, widget.location.longitude);
     return FlutterMap(
-      options: MapOptions(center: centerPoint, maxZoom: 19),
+      options: MapOptions(center: markerPoint, maxZoom: 19),
       children: <Widget>[
         TileLayer(
           urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/learnify/mobile/lib/features/learning-space/view/components/events/event_map.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/event_map.dart
@@ -1,0 +1,23 @@
+part of '../../learning_space_detail_screen.dart';
+
+class _EventMap extends StatefulWidget {
+  const _EventMap({required this.location, Key? key}) : super(key: key);
+  final GeoLocation location;
+
+  @override
+  State<_EventMap> createState() => __EventMapState();
+}
+
+class __EventMapState extends State<_EventMap> {
+  @override
+  Widget build(BuildContext context) => FlutterMap(
+        options: MapOptions(
+            center: LatLng(35.269259, 33.825730), maxZoom: 19, zoom: 16),
+        children: <Widget>[
+          TileLayer(
+            urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+            userAgentPackageName: 'com.bounswe.learnify',
+          ),
+        ],
+      );
+}

--- a/learnify/mobile/lib/features/learning-space/view/learning_space_detail_screen.dart
+++ b/learnify/mobile/lib/features/learning-space/view/learning_space_detail_screen.dart
@@ -2,7 +2,9 @@ import 'dart:math';
 
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:intl/intl.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 import 'package:tuple/tuple.dart';
 
@@ -12,7 +14,6 @@ import '../../../core/extensions/context/context_extensions.dart';
 import '../../../core/extensions/context/theme_extensions.dart';
 import '../../../core/extensions/number/number_extensions.dart';
 import '../../../core/helpers/selector_helper.dart';
-import '../../../core/managers/local/local_manager.dart';
 import '../../../core/managers/navigation/navigation_manager.dart';
 import '../../../core/widgets/base-icon/base_icon.dart';
 import '../../../core/widgets/buttons/action_button.dart';
@@ -27,9 +28,7 @@ import '../../../core/widgets/text/base_text.dart';
 import '../../../core/widgets/text/multiline_text.dart';
 import '../../../product/constants/icon_keys.dart';
 import '../../../product/constants/navigation_constants.dart';
-import '../../../product/constants/storage_keys.dart';
 import '../../../product/language/language_keys.dart';
-import '../../auth/verification/model/user_model.dart';
 import '../../home/view-model/home_view_model.dart';
 import '../constants/learning_space_constants.dart';
 import '../models/annotation/annotation_model.dart';

--- a/learnify/mobile/lib/features/learning-space/view/learning_space_detail_screen.dart
+++ b/learnify/mobile/lib/features/learning-space/view/learning_space_detail_screen.dart
@@ -33,12 +33,14 @@ import '../../home/view-model/home_view_model.dart';
 import '../constants/learning_space_constants.dart';
 import '../models/annotation/annotation_model.dart';
 import '../models/event.dart';
+import '../models/geolocation/geolocation_model.dart';
 import '../models/learning_space_model.dart';
 import '../models/post_model.dart';
 import '../view-model/learning_space_view_model.dart';
 import 'annotations_screen.dart';
 
 part 'components/events/event_item.dart';
+part 'components/events/event_map.dart';
 part 'components/events/events_list.dart';
 part 'components/forum_list.dart';
 part 'components/post/post_item.dart';

--- a/learnify/mobile/pubspec.yaml
+++ b/learnify/mobile/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   cached_network_image: ^3.2.2
   flutter_native_splash: ^2.2.14
   page_transition: ^2.0.9
+  flutter_map: ^3.0.0
+  latlong2: ^0.8.1
 
   # Model
   equatable: ^2.0.5


### PR DESCRIPTION
## Short Description

This PR integrates the [Open Street Map](https://www.openstreetmap.org/#map=6/39.031/35.252) into our application. Events have location information inside them which is set by the event creator. Therefore, we need to display the location of the event to the users. We used the free Open Street Map and integrated its map into our event item. This PR also will create and integrate corresponding classes/models.

------

## What Does This PR Include?

1. Integrate the [Flutter_Map](https://pub.dev/packages/flutter_map) package to embed the Open Street Map.
2. Integrate the [latlong2](https://pub.dev/packages/latlong2) package for common latitude/longitude calculations
3. Create GeoLocation model acc. to the [W3C standards](https://www.w3.org/TR/geolocation/) 
4. Add an event location marker to the map 
5. Modify the event model to integrate the new GeoLocation class
6. Create dummy creator methods for GeoLocation

------

Closes #750 
