### PR TITLE
Mobile: Event List and Preview Test

### DIFF
--- a/learnify/mobile/assets/lang/en.json
+++ b/learnify/mobile/assets/lang/en.json
@@ -80,6 +80,7 @@
   "click_image_annotations": "Click on image for annotations",
   "create_event": "Create an Event",
   "edit_event": "Edit the Event",
+  "attend_event": "Attend Event",
   "event_date": "Event Date",
   "event_duration": "Duration",
   "event_participation_limit": "Participation Limit",

--- a/learnify/mobile/lib/features/home/view-model/home_view_model.dart
+++ b/learnify/mobile/lib/features/home/view-model/home_view_model.dart
@@ -49,6 +49,26 @@ class HomeViewModel extends BaseViewModel {
   @override
   void initViewModel() {
     _homeService = HomeService.instance;
+    randomUsers = List<Map<String, dynamic>>.generate(
+      70,
+      (int i) => <String, dynamic>{
+        'name': {"title": "Ms", "first": "Francisca", "last": "García"},
+        'picture': {
+          if (i % 6 == 0)
+            'medium': "https://randomuser.me/api/portraits/med/women/73.jpg"
+          else if (i % 6 == 1)
+            'medium': "https://randomuser.me/api/portraits/med/men/71.jpg"
+          else if (i % 6 == 2)
+            'medium': "https://randomuser.me/api/portraits/med/women/4.jpg"
+          else if (i % 6 == 3)
+            'medium': "https://randomuser.me/api/portraits/med/men/6.jpg"
+          else if (i % 6 == 4)
+            'medium': "https://randomuser.me/api/portraits/med/women/9.jpg"
+          else if (i % 6 == 5)
+            'medium': "https://randomuser.me/api/portraits/med/men/12.jpg"
+        }
+      },
+    );
   }
 
   @override

--- a/learnify/mobile/lib/features/home/view/home_screen.dart
+++ b/learnify/mobile/lib/features/home/view/home_screen.dart
@@ -21,7 +21,7 @@ class HomeScreen extends BaseView<HomeViewModel> {
           builder: _builder,
           scrollable: true,
           hasScaffold: false,
-          futureInit: (BuildContext context) =>
+          futureInit: (BuildContext context) async =>
               context.read<HomeViewModel>().fetchInitialLearningSpaces(),
           key: key,
         );

--- a/learnify/mobile/lib/features/learning-space/view-model/learning_space_view_model.dart
+++ b/learnify/mobile/lib/features/learning-space/view-model/learning_space_view_model.dart
@@ -63,7 +63,7 @@ class LearningSpaceViewModel extends BaseViewModel {
     _lsService = LSService.instance;
     _posts = learningSpace?.posts ?? <Post>[];
     // _posts = List<Post>.generate(20, Post.dummy);
-    _events = List<Event>.generate(Random().nextInt(5), Event.dummy);
+    _events = List<Event>.generate(3, Event.dummy);
     _events
       ..sort((Event e1, Event e2) => e1.date.compareTo(e2.date))
       ..sort((Event e1, Event e2) => e1.date.isBefore(DateTime.now()) ? 1 : -1);
@@ -81,7 +81,7 @@ class LearningSpaceViewModel extends BaseViewModel {
     _learningSpace = newSpace;
     _posts = newSpace?.posts ?? <Post>[];
     // _posts = List<Post>.generate(20, Post.dummy);
-    _events = List<Event>.generate(Random().nextInt(5), Event.dummy);
+    _events = List<Event>.generate(3, Event.dummy);
     _events
       ..sort((Event e1, Event e2) => e1.date.compareTo(e2.date))
       ..sort((Event e1, Event e2) => e1.date.isBefore(DateTime.now()) ? 1 : -1);

--- a/learnify/mobile/lib/features/learning-space/view-model/learning_space_view_model.dart
+++ b/learnify/mobile/lib/features/learning-space/view-model/learning_space_view_model.dart
@@ -69,10 +69,6 @@ class LearningSpaceViewModel extends BaseViewModel {
       ..sort((Event e1, Event e2) => e1.date.isBefore(DateTime.now()) ? 1 : -1);
   }
 
-  void _createEvents() {
-    _events = List<Event>.generate(Random().nextInt(5), Event.dummy);
-  }
-
   @override
   void disposeViewModel() {}
 
@@ -148,7 +144,7 @@ class LearningSpaceViewModel extends BaseViewModel {
     return null;
   }
 
-  Future<String?> editEvent() async {
+  Future<String?> attendEvent() async {
     // TODO: Fix
     // await navigationManager.navigateToPage(
     //     path: NavigationConstants.createEditPost);
@@ -341,5 +337,11 @@ class LearningSpaceViewModel extends BaseViewModel {
     _initializeKeys();
     notifyListeners();
     return _learningSpace;
+  }
+
+  void setEvents(List<Event> newEvents) {
+    if (newEvents != _events) {
+      _events = newEvents;
+    }
   }
 }

--- a/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
@@ -36,7 +36,8 @@ class EventItem extends StatelessWidget {
   Widget _expansionTile(BuildContext context, Event event) {
     final LearningSpaceViewModel viewModel =
         context.read<LearningSpaceViewModel>();
-    User user = LocalManager.instance.getModel(const User(), StorageKeys.user);
+    final User user =
+        LocalManager.instance.getModel(const User(), StorageKeys.user);
     final List<Map<String, dynamic>> userList = context
         .read<HomeViewModel>()
         .randomUsers

--- a/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
@@ -36,6 +36,7 @@ class EventItem extends StatelessWidget {
   Widget _expansionTile(BuildContext context, Event event) {
     final LearningSpaceViewModel viewModel =
         context.read<LearningSpaceViewModel>();
+    User user = LocalManager.instance.getModel(const User(), StorageKeys.user);
     final List<Map<String, dynamic>> userList = context
         .read<HomeViewModel>()
         .randomUsers
@@ -116,11 +117,12 @@ class EventItem extends StatelessWidget {
                 _EventMap(location: event.geoLocation ?? const GeoLocation()),
           ),
         ),
-        PostList.createEditButton(
-            context,
-            isPassed ? TextKeys.passedEvent : TextKeys.editEvent,
-            isPassed ? Icons.timer_off_outlined : Icons.edit_outlined,
-            isPassed ? null : viewModel.editEvent),
+        if (event.eventCreator != user.id)
+          PostList.createEditButton(
+              context,
+              isPassed ? TextKeys.passedEvent : TextKeys.attendEvent,
+              isPassed ? Icons.timer_off_outlined : Icons.join_inner_outlined,
+              isPassed ? null : viewModel.attendEvent),
       ],
     );
   }

--- a/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/event_item.dart
@@ -5,33 +5,30 @@ class EventItem extends StatelessWidget {
     required this.callback,
     required this.itemIndex,
     required this.expansionTileKey,
+    required this.event,
     Key? key,
   }) : super(key: key);
   final int itemIndex;
   final IndexCallback callback;
   final GlobalKey<CustomExpansionTileState> expansionTileKey;
+  final Event event;
 
   @override
-  Widget build(BuildContext context) {
-    final Event event = SelectorHelper<Event, LearningSpaceViewModel>()
-        .listenValue(
-            (LearningSpaceViewModel model) => model.events[itemIndex], context);
-    return Theme(
-      data: Theme.of(context).copyWith(
-        dividerColor: Colors.transparent,
-        highlightColor: context.primary.withOpacity(.15),
-        hoverColor: context.primary,
-      ),
-      child: ListTileTheme(
-        contentPadding: EdgeInsets.zero,
-        minLeadingWidth: 0,
-        minVerticalPadding: 0,
-        horizontalTitleGap: 0,
-        dense: true,
-        child: _expansionTile(context, event),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => Theme(
+        data: Theme.of(context).copyWith(
+          dividerColor: Colors.transparent,
+          highlightColor: context.primary.withOpacity(.15),
+          hoverColor: context.primary,
+        ),
+        child: ListTileTheme(
+          contentPadding: EdgeInsets.zero,
+          minLeadingWidth: 0,
+          minVerticalPadding: 0,
+          horizontalTitleGap: 0,
+          dense: true,
+          child: _expansionTile(context, event),
+        ),
+      );
 
   Widget _expansionTile(BuildContext context, Event event) {
     final LearningSpaceViewModel viewModel =

--- a/learnify/mobile/lib/features/learning-space/view/components/events/events_list.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/events/events_list.dart
@@ -7,13 +7,14 @@ class EventsList extends StatelessWidget {
   Widget build(BuildContext context) {
     final LearningSpaceViewModel viewModel =
         context.read<LearningSpaceViewModel>();
-    final Tuple2<int, List<GlobalKey<CustomExpansionTileState>>> tuple =
-        SelectorHelper<Tuple2<int, List<GlobalKey<CustomExpansionTileState>>>,
+    final Tuple2<List<Event>, List<GlobalKey<CustomExpansionTileState>>> tuple =
+        SelectorHelper<
+                Tuple2<List<Event>, List<GlobalKey<CustomExpansionTileState>>>,
                 LearningSpaceViewModel>()
             .listenValue(
-                (LearningSpaceViewModel model) =>
-                    Tuple2<int, List<GlobalKey<CustomExpansionTileState>>>(
-                        model.events.length, model.eventsExpansionTileKeys),
+                (LearningSpaceViewModel model) => Tuple2<List<Event>,
+                        List<GlobalKey<CustomExpansionTileState>>>(
+                    model.events, model.eventsExpansionTileKeys),
                 context);
     final List<GlobalKey<CustomExpansionTileState>> keys = tuple.item2;
     return SliverList(
@@ -30,6 +31,7 @@ class EventsList extends StatelessWidget {
                         EdgeInsets.symmetric(vertical: context.height * .3),
                     child: EventItem(
                       itemIndex: i - 1,
+                      event: tuple.item1[i - 1],
                       callback: (int itemIndex) =>
                           PostList.updateExpansions(itemIndex, keys),
                       expansionTileKey: keys[i - 1],
@@ -38,7 +40,7 @@ class EventsList extends StatelessWidget {
                   const CustomDivider(),
                 ],
               ),
-        childCount: tuple.item1 + 1,
+        childCount: tuple.item1.length + 1,
       ),
     );
   }

--- a/learnify/mobile/lib/features/learning-space/view/learning_space_detail_screen.dart
+++ b/learnify/mobile/lib/features/learning-space/view/learning_space_detail_screen.dart
@@ -14,6 +14,7 @@ import '../../../core/extensions/context/context_extensions.dart';
 import '../../../core/extensions/context/theme_extensions.dart';
 import '../../../core/extensions/number/number_extensions.dart';
 import '../../../core/helpers/selector_helper.dart';
+import '../../../core/managers/local/local_manager.dart';
 import '../../../core/managers/navigation/navigation_manager.dart';
 import '../../../core/widgets/base-icon/base_icon.dart';
 import '../../../core/widgets/buttons/action_button.dart';
@@ -28,7 +29,9 @@ import '../../../core/widgets/text/base_text.dart';
 import '../../../core/widgets/text/multiline_text.dart';
 import '../../../product/constants/icon_keys.dart';
 import '../../../product/constants/navigation_constants.dart';
+import '../../../product/constants/storage_keys.dart';
 import '../../../product/language/language_keys.dart';
+import '../../auth/verification/model/user_model.dart';
 import '../../home/view-model/home_view_model.dart';
 import '../constants/learning_space_constants.dart';
 import '../models/annotation/annotation_model.dart';
@@ -48,9 +51,11 @@ part 'components/post/post_list.dart';
 
 class LearningSpaceDetailScreen extends BaseView<LearningSpaceViewModel>
     with LearningSpaceConstants {
-  LearningSpaceDetailScreen({required LearningSpace? learningSpace, Key? key})
+  LearningSpaceDetailScreen(
+      {required LearningSpace? learningSpace, int initialIndex = 0, Key? key})
       : super(
-          builder: (BuildContext context) => _builder(context, learningSpace),
+          builder: (BuildContext context) =>
+              _builder(context, learningSpace, initialIndex),
           voidInit: (BuildContext context) => context
               .read<LearningSpaceViewModel>()
               .setLearningSpace(learningSpace),
@@ -58,8 +63,10 @@ class LearningSpaceDetailScreen extends BaseView<LearningSpaceViewModel>
           key: key,
         );
 
-  static Widget _builder(BuildContext context, LearningSpace? learningSpace) =>
+  static Widget _builder(BuildContext context, LearningSpace? learningSpace,
+          int initialIndex) =>
       DefaultTabController(
+        initialIndex: initialIndex,
         length: LearningSpaceConstants.tabKeys.length,
         child: NestedScrollView(
           headerSliverBuilder: _headerSliverBuilder,

--- a/learnify/mobile/lib/product/language/language_keys.dart
+++ b/learnify/mobile/lib/product/language/language_keys.dart
@@ -81,6 +81,7 @@ class TextKeys {
   static const String clickToSeeImageAnnotations = "click_image_annotations";
   static const String createEvent = "create_event";
   static const String editEvent = "edit_event";
+  static const String attendEvent = "attend_event";
   static const String eventDate = "event_date";
   static const String eventDuration = "event_duration";
   static const String eventParticipationLimit = "event_participation_limit";

--- a/learnify/mobile/test/events/events_list_preview_test.dart
+++ b/learnify/mobile/test/events/events_list_preview_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
+import 'package:learnify/core/widgets/buttons/action_button.dart';
 import 'package:learnify/core/widgets/list/custom_expansion_tile.dart';
 import 'package:learnify/core/widgets/text/base_text.dart';
 import 'package:learnify/features/learning-space/models/event.dart';
@@ -44,6 +45,13 @@ void main() {
       final SliverChildBuilderDelegate sliverDelegate =
           sliverList.delegate as SliverChildBuilderDelegate;
       expect(sliverDelegate.childCount, 4);
+
+      final Finder createEventButtonFinder =
+          TestHelpers.descendantFinder(eventsList, ActionButton);
+      expect(createEventButtonFinder, findsWidgets);
+      final ActionButton createEventButton =
+          tester.widget(createEventButtonFinder.first) as ActionButton;
+      expect(createEventButton.isActive, true);
 
       final Finder eventFinder =
           TestHelpers.descendantFinder(eventsList, EventItem);

--- a/learnify/mobile/test/events/events_view_test.dart
+++ b/learnify/mobile/test/events/events_view_test.dart
@@ -40,6 +40,13 @@ void main() {
       final SliverChildBuilderDelegate sliverDelegate =
           sliverList.delegate as SliverChildBuilderDelegate;
       expect(sliverDelegate.childCount, 4);
+
+      final Finder eventFinder =
+          TestHelpers.descendantFinder(eventsList, EventItem);
+      expect(eventFinder, findsWidgets);
+      final EventItem firstEvent =
+          tester.widget(eventFinder.first) as EventItem;
+      expect(firstEvent.itemIndex, 0);
     },
   );
 }

--- a/learnify/mobile/test/events/events_view_test.dart
+++ b/learnify/mobile/test/events/events_view_test.dart
@@ -12,9 +12,7 @@ void main() {
       late final LearningSpace dummyLearningSpace = LearningSpace.dummy(1);
       final LearningSpaceDetailScreen detailScreen = LearningSpaceDetailScreen(
           learningSpace: dummyLearningSpace, initialIndex: 2);
-      await tester.pumpWidget(
-        TestHelpers.appWidget(detailScreen),
-      );
+      await tester.pumpWidget(TestHelpers.appWidget(detailScreen));
 
       final Finder tabFinder =
           TestHelpers.descendantFinder(detailScreen, DefaultTabController);
@@ -31,11 +29,17 @@ void main() {
       final Finder eventsListFinder =
           TestHelpers.descendantFinder(detailScreen, EventsList);
       expect(eventsListFinder, findsOneWidget);
+      final EventsList eventsList =
+          tester.widget(eventsListFinder) as EventsList;
 
-      // expect(eventsList., equals(1));
-      // final Finder postListFinder =
-      //     TestHelpers.descendantFinder(detailScreen, PostList);
-      // expect(postListFinder, findsOneWidget);
+      final Finder sliverListFinder =
+          TestHelpers.descendantFinder(eventsList, SliverList);
+      expect(sliverListFinder, findsOneWidget);
+      final SliverList sliverList =
+          tester.widget(sliverListFinder) as SliverList;
+      final SliverChildBuilderDelegate sliverDelegate =
+          sliverList.delegate as SliverChildBuilderDelegate;
+      expect(sliverDelegate.childCount, 4);
     },
   );
 }

--- a/learnify/mobile/test/events/events_view_test.dart
+++ b/learnify/mobile/test/events/events_view_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:learnify/core/widgets/list/custom_expansion_tile.dart';
 import 'package:learnify/features/learning-space/models/learning_space_model.dart';
 import 'package:learnify/features/learning-space/view/learning_space_detail_screen.dart';
 
@@ -47,6 +48,10 @@ void main() {
       final EventItem firstEvent =
           tester.widget(eventFinder.first) as EventItem;
       expect(firstEvent.itemIndex, 0);
+
+      final Finder expansionTileFinder =
+          TestHelpers.descendantFinder(firstEvent, CustomExpansionTile);
+      expect(expansionTileFinder, findsOneWidget);
     },
   );
 }

--- a/learnify/mobile/test/events/events_view_test.dart
+++ b/learnify/mobile/test/events/events_view_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:learnify/core/widgets/list/custom_expansion_tile.dart';
+import 'package:learnify/core/widgets/text/base_text.dart';
+import 'package:learnify/features/learning-space/models/event.dart';
 import 'package:learnify/features/learning-space/models/learning_space_model.dart';
 import 'package:learnify/features/learning-space/view/learning_space_detail_screen.dart';
 
@@ -52,6 +55,24 @@ void main() {
       final Finder expansionTileFinder =
           TestHelpers.descendantFinder(firstEvent, CustomExpansionTile);
       expect(expansionTileFinder, findsOneWidget);
+      final CustomExpansionTile expansionTile =
+          tester.widget(expansionTileFinder) as CustomExpansionTile;
+
+      final Event eventModel = firstEvent.event;
+
+      final Widget eventTitle = expansionTile.title;
+      expect(eventTitle.runtimeType, Row);
+      final Row titleWidget = expansionTile.title as Row;
+      expect(titleWidget.children[0].runtimeType, Flexible);
+      final Flexible titleTextWrapper = titleWidget.children[0] as Flexible;
+      expect(titleWidget.children[1].runtimeType, BaseText);
+      final BaseText dateText = titleWidget.children[1] as BaseText;
+      expect(titleTextWrapper.child.runtimeType, BaseText);
+      final BaseText titleText = titleTextWrapper.child as BaseText;
+      expect(
+          titleText.text, '${firstEvent.itemIndex + 1}. ${eventModel.title}');
+      expect(
+          dateText.text, DateFormat('dd MMM - kk:mm').format(eventModel.date));
     },
   );
 }

--- a/learnify/mobile/test/events/events_view_test.dart
+++ b/learnify/mobile/test/events/events_view_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:learnify/features/learning-space/models/learning_space_model.dart';
 import 'package:learnify/features/learning-space/view/learning_space_detail_screen.dart';
@@ -14,6 +15,22 @@ void main() {
       await tester.pumpWidget(
         TestHelpers.appWidget(detailScreen),
       );
+
+      final Finder tabFinder =
+          TestHelpers.descendantFinder(detailScreen, DefaultTabController);
+      expect(tabFinder, findsOneWidget);
+      final DefaultTabController tabController =
+          tester.widget(tabFinder) as DefaultTabController;
+      expect(tabController.initialIndex, equals(2));
+
+      final Finder tabViewFinder =
+          TestHelpers.descendantFinder(detailScreen, TabBarView);
+      final TabBarView tabView = tester.widget(tabViewFinder) as TabBarView;
+      expect(tabView.children.length, equals(3));
+
+      final Finder eventsListFinder =
+          TestHelpers.descendantFinder(detailScreen, EventsList);
+      expect(eventsListFinder, findsOneWidget);
 
       // expect(eventsList., equals(1));
       // final Finder postListFinder =

--- a/learnify/mobile/test/events/events_view_test.dart
+++ b/learnify/mobile/test/events/events_view_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:learnify/features/learning-space/models/learning_space_model.dart';
+import 'package:learnify/features/learning-space/view/learning_space_detail_screen.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  testWidgets(
+    "Test view events functionality.",
+    (WidgetTester tester) async {
+      late final LearningSpace dummyLearningSpace = LearningSpace.dummy(1);
+      final LearningSpaceDetailScreen detailScreen = LearningSpaceDetailScreen(
+          learningSpace: dummyLearningSpace, initialIndex: 2);
+      await tester.pumpWidget(
+        TestHelpers.appWidget(detailScreen),
+      );
+
+      // expect(eventsList., equals(1));
+      // final Finder postListFinder =
+      //     TestHelpers.descendantFinder(detailScreen, PostList);
+      // expect(postListFinder, findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## Short Description

This PR implements the tests for the events list and event preview item under the learning space detail screen. It will both test the list count, screen details, and also the data of the previewed event item.

------

## What Does This PR Include?

1. Converts edit event button to attend event button
2. Adds dummy random user data for testing purposes
3. Tests the correctness of the number of events
4. Finds and test the existence of the first event in the list
5. Finds and test the existence of the expansion tile widget under the event item
6. Tests the correctness of the event title and event data information
7. Tests the existence of the create event button

------

Closes #753 