### PR TITLE
Frontend: Learning Space Preview Box BE Connection

### DIFF
--- a/learnify/web/src/components/LearningSpacePrev.js
+++ b/learnify/web/src/components/LearningSpacePrev.js
@@ -45,10 +45,13 @@ export default function LearningSpacePrev(props) {
         lslogo_19, 
         lslogo_20
     ]
-    
+
     return (
         <div>
-            <div className='learning-space-card'>
+            <div className='learning-space-card' data-testid="ls-prev-card" onClick={(e) => {
+                e.preventDefault();
+                window.location.href = '/learning-space/' + props.url;
+            }}>
                 <div>
                     <img src={props.icon} className="learning-space-icon" alt="learning space logo" height={140} />
                 </div>

--- a/learnify/web/src/components/LearningSpacePrev.js
+++ b/learnify/web/src/components/LearningSpacePrev.js
@@ -21,7 +21,7 @@ import lslogo_18 from '../images/ls_icons/ls-icon-18.svg'
 import lslogo_19 from '../images/ls_icons/ls-icon-19.svg'
 import lslogo_20 from '../images/ls_icons/ls-icon-20.svg'
 
-export default function LearningSpacePrev(props) {
+function LearningSpacePrev(props) {
 
     const icons = [
         lslogo_1, 
@@ -47,18 +47,18 @@ export default function LearningSpacePrev(props) {
     ]
 
     return (
-        <div>
-            <div className='learning-space-card' data-testid="ls-prev-card" onClick={(e) => {
-                e.preventDefault();
-                window.location.href = '/learning-space/' + props.url;
+        <div className='learning-space-card' data-testid="ls-prev-card" onClick={(e) => {
+            e.preventDefault();
+            window.location.href = '/learning-space/' + props.url;
             }}>
-                <div>
-                    <img src={props.icon} className="learning-space-icon" alt="learning space logo" height={140} />
-                </div>
-                <label className='learning-space-title'>
-                    {props.name}
-                </label>
+            <div className='ls-prev-box-icon'>
+                <img src={icons[props.icon_id - 1]} className="learning-space-icon" alt="learning space icon" height={140} />
             </div>
+            <label className='learning-space-title'>
+                {props.title}
+            </label>
         </div>
     );
   }
+
+  export default LearningSpacePrev;

--- a/learnify/web/src/components/LearningSpacePrev.js
+++ b/learnify/web/src/components/LearningSpacePrev.js
@@ -22,6 +22,30 @@ import lslogo_19 from '../images/ls_icons/ls-icon-19.svg'
 import lslogo_20 from '../images/ls_icons/ls-icon-20.svg'
 
 export default function LearningSpacePrev(props) {
+
+    const icons = [
+        lslogo_1, 
+        lslogo_2, 
+        lslogo_3, 
+        lslogo_4, 
+        lslogo_5, 
+        lslogo_6, 
+        lslogo_7, 
+        lslogo_8, 
+        lslogo_9, 
+        lslogo_10, 
+        lslogo_11, 
+        lslogo_12, 
+        lslogo_13, 
+        lslogo_14, 
+        lslogo_15, 
+        lslogo_16, 
+        lslogo_17, 
+        lslogo_18, 
+        lslogo_19, 
+        lslogo_20
+    ]
+    
     return (
         <div>
             <div className='learning-space-card'>

--- a/learnify/web/src/components/LearningSpacePrev.js
+++ b/learnify/web/src/components/LearningSpacePrev.js
@@ -1,5 +1,25 @@
 import * as React from 'react';
 import './component_styles.css';
+import lslogo_1 from '../images/ls_icons/ls-icon-1.svg'
+import lslogo_2 from '../images/ls_icons/ls-icon-2.svg'
+import lslogo_3 from '../images/ls_icons/ls-icon-3.svg'
+import lslogo_4 from '../images/ls_icons/ls-icon-4.svg'
+import lslogo_5 from '../images/ls_icons/ls-icon-5.svg'
+import lslogo_6 from '../images/ls_icons/ls-icon-6.svg'
+import lslogo_7 from '../images/ls_icons/ls-icon-7.svg'
+import lslogo_8 from '../images/ls_icons/ls-icon-8.svg'
+import lslogo_9 from '../images/ls_icons/ls-icon-9.svg'
+import lslogo_10 from '../images/ls_icons/ls-icon-10.svg'
+import lslogo_11 from '../images/ls_icons/ls-icon-11.svg'
+import lslogo_12 from '../images/ls_icons/ls-icon-12.svg'
+import lslogo_13 from '../images/ls_icons/ls-icon-13.svg'
+import lslogo_14 from '../images/ls_icons/ls-icon-14.svg'
+import lslogo_15 from '../images/ls_icons/ls-icon-15.svg'
+import lslogo_16 from '../images/ls_icons/ls-icon-16.svg'
+import lslogo_17 from '../images/ls_icons/ls-icon-17.svg'
+import lslogo_18 from '../images/ls_icons/ls-icon-18.svg'
+import lslogo_19 from '../images/ls_icons/ls-icon-19.svg'
+import lslogo_20 from '../images/ls_icons/ls-icon-20.svg'
 
 export default function LearningSpacePrev(props) {
     return (

--- a/learnify/web/src/components/component_styles.css
+++ b/learnify/web/src/components/component_styles.css
@@ -8,6 +8,7 @@
     background-color: #1746A2;
     border-radius: 20px;
     box-shadow: 0px 2px 8px 0px rgba(120,120,120,0.52);
+    cursor: pointer;
 }
 
 .learning-space-icon {
@@ -529,3 +530,9 @@
     transition: background-color 0s cubic-bezier(0.4, 0, 0.2, 1) 0s, box-shadow 0s cubic-bezier(0.4, 0, 0.2, 1) 0s, color 0s cubic-bezier(0.4, 0, 0.2, 1) 0s;	
 
 }
+
+.ls-prev-box-icon {
+    border-radius: 20px;
+    box-shadow: inset 0px 0px 54px -23px rgba(87,87,87,0.7);
+}
+


### PR DESCRIPTION
## PR Description:
I have modified the learning space preview box component as it is fully customizable for backend connection. Until now, it featured static components. It featured props parameters. But, those parameters were not passed dynamically, instead as fixed static keywords. This new version accepts the parameters as it will be given by endpoint response.

***
## Notes:
* The props parameters that will be used are:
> * url
> * icon_id
> * title
* The component is now clickable and directs the user to the related learning space page.
* It is now compatible with the response of GET learningspace endpoints.
***
## Routine Check
- [x] I have fetched and pulled the latest version of the parent branch.
- [x] This PR does not have any conflicts with the parent branch.
***
## Corresponding Issue
Closes #766 
