### PR TITLE
Frontend: Popular Learning Spaces Page

### DIFF
--- a/learnify/web/src/App.js
+++ b/learnify/web/src/App.js
@@ -18,6 +18,7 @@ import LearningSpace from './pages/LearningSpace';
 import CategoriesPage from './pages/CategoriesPage';
 import LSbyCategoryPage from './pages/LSbyCategoryPage';
 import MyLearningSpacesPage from './pages/MyLearningSpacesPage';
+import PopularLearningSpacesPage from './pages/PopularLearningSpacesPage';
 
 
 function App() {
@@ -38,6 +39,7 @@ function App() {
           <Route path="/categories/:category" element={<PrivateRoutes> <LSbyCategoryPage /> </PrivateRoutes>}/>
           <Route path="/learningspace/:lsid" element={<PrivateRoutes> <LearningSpace /> </PrivateRoutes>}/>
           <Route path="/:username/learningspaces" element={<PrivateRoutes> <MyLearningSpacesPage /> </PrivateRoutes>}/>
+          <Route path="/popular" element={<PrivateRoutes> <PopularLearningSpacesPage /> </PrivateRoutes>}/>
           <Route path='*' element={<NotFoundPage/>} />
         </Routes>
       </BrowserRouter>

--- a/learnify/web/src/pages/HomePage.js
+++ b/learnify/web/src/pages/HomePage.js
@@ -124,7 +124,10 @@ function HomePage() {
                                 Popular Learning Spaces
                             </label>
                         </div>
-                        <button className='ls-box-button'>
+                        <button className='ls-box-button' onClick={(e) => {
+                            e.preventDefault();
+                            window.location.href=`/popular`;
+                            }}>
                             view all
                         </button>
                     </div>

--- a/learnify/web/src/pages/PopularLearningSpacesPage.js
+++ b/learnify/web/src/pages/PopularLearningSpacesPage.js
@@ -10,6 +10,16 @@ function PopularLearningSpacesPage() {
     return (
         <div>
             <NavBar/>
+            <div className="popularlspage-container">
+                <div className="popularlspage-wrapper">
+                    <div className="popularlspage-title">
+                        <h1>Browsing the current most popular learning spaces:</h1>
+                    </div>
+                </div>
+                <div className="popularlspage-body" data-testid="popularls-body">
+                    {lsBoxes}
+                </div>
+            </div>
         </div>
     )
 }

--- a/learnify/web/src/pages/PopularLearningSpacesPage.js
+++ b/learnify/web/src/pages/PopularLearningSpacesPage.js
@@ -11,7 +11,18 @@ function PopularLearningSpacesPage() {
 
     const token = localStorage.getItem('token');
 
-    
+    useEffect(() => {
+        const getPopularLearningSpaces = async () => {
+            const res = await axios.get(`${process.env.REACT_APP_BACKEND_BASE_URL}learningspace`, {
+                headers: {
+                    'Content-type': 'application/json; charset=UTF-8',
+                    'Authorization': `${token}`,
+                }
+            });
+            setLearningspaces(res.data.learning_spaces);
+        }
+        getPopularLearningSpaces();
+    }, []);
 
     return (
         <div>

--- a/learnify/web/src/pages/PopularLearningSpacesPage.js
+++ b/learnify/web/src/pages/PopularLearningSpacesPage.js
@@ -1,0 +1,17 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import './style.css';
+import LearningSpaceDetailBox from '../components/LearningSpaceDetailBox';
+import Footer from '../components/Footer';
+import NavBar from '../components/NavBar';
+
+function PopularLearningSpacesPage() {
+
+    return (
+        <div>
+            <NavBar/>
+        </div>
+    )
+}
+
+export default PopularLearningSpacesPage;

--- a/learnify/web/src/pages/PopularLearningSpacesPage.js
+++ b/learnify/web/src/pages/PopularLearningSpacesPage.js
@@ -20,6 +20,7 @@ function PopularLearningSpacesPage() {
                     {lsBoxes}
                 </div>
             </div>
+            <Footer/>
         </div>
     )
 }

--- a/learnify/web/src/pages/PopularLearningSpacesPage.js
+++ b/learnify/web/src/pages/PopularLearningSpacesPage.js
@@ -7,6 +7,12 @@ import NavBar from '../components/NavBar';
 
 function PopularLearningSpacesPage() {
 
+    const [learningspaces, setLearningspaces] = useState([])
+
+    const token = localStorage.getItem('token');
+
+    
+
     return (
         <div>
             <NavBar/>

--- a/learnify/web/src/pages/PopularLearningSpacesPage.js
+++ b/learnify/web/src/pages/PopularLearningSpacesPage.js
@@ -24,6 +24,10 @@ function PopularLearningSpacesPage() {
         getPopularLearningSpaces();
     }, []);
 
+    const lsBoxes = learningspaces.slice(0, 10).map(ls => (
+        <LearningSpaceDetailBox title={ls.title} description={ls.description} icon_id={ls.icon_id} num_participants={ls.num_participants} url={ls._id}/>
+    ));
+
     return (
         <div>
             <NavBar/>

--- a/learnify/web/src/pages/style.css
+++ b/learnify/web/src/pages/style.css
@@ -1076,3 +1076,42 @@ h1 {
     height: 100%;
     background-color: #FFF7E9;
 }
+
+.popularlspage-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-height: calc(100vh - 190px);
+}
+
+.popularlspage-wrapper {
+    display: flex;
+    flex-direction: row;
+    padding-right: 36px;
+}
+
+.popularlspage-title {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    height: 10%;
+    width: max-content;
+    color: black;
+    font-family: 'Open Sans' sans-serif;
+    font-size: 24px;
+    font-weight: 700;
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin: 10px;
+    border-radius: 5px;
+}
+
+.popularlspage-body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    height: 100%;
+    background-color: #FFF7E9;
+}


### PR DESCRIPTION
## PR Description:
I have implemented the popular learning spaces page. It is an independent page and can be reached from the related view all button on the home page and displays the most popular 10 learning spaces. The page uses the useEffect hook to retrieve a list of learning spaces from the backend server and displays them using the LearningSpaceDetailBox component. The page also includes a navigation bar and a footer.

***
## Notes:
* The endpoint that is used was /learningspace.
* The page uses the axios library to make a GET request to the backend server to retrieve the list of learning spaces. The request includes an Authorization header with the value of the token stored in local storage.
* The page makes use of the useState hook to store the list of learning spaces in a state variable.
* The list of learning spaces is sliced to only include the first 10 elements before being mapped to JSX elements and rendered on the page.
* Each learning space detail box featured in the page is clickable and takes the user to that learning space's own page.
* The page exports a default React component called PopularLearningSpacesPage.
***
## Routine Check
- [x] I have fetched and pulled the latest version of the parent branch.
- [x] This PR does not have any conflicts with the parent branch.
***
## Corresponding Issue
Closes #808 
