### PR TITLE
Mobile: HOTFIX Remove Default Images

### DIFF
--- a/learnify/mobile/lib/core/managers/network/network_manager.dart
+++ b/learnify/mobile/lib/core/managers/network/network_manager.dart
@@ -41,7 +41,7 @@ class NetworkManager extends INetworkManager
   }
 
   static final NetworkManager _instance = NetworkManager._init();
-  static const String _baseUrl = NetworkConstants.localhostUrl;
+  static const String _baseUrl = NetworkConstants.productionUrl;
 
   /// Returns the singleton instance of the network manager.
   static NetworkManager get instance => _instance;

--- a/learnify/mobile/lib/core/widgets/text/annotatable/annotatable_text.dart
+++ b/learnify/mobile/lib/core/widgets/text/annotatable/annotatable_text.dart
@@ -93,7 +93,7 @@ class AnnotatableText extends StatelessWidget {
 
   List<_AnnotatableTextItem> _mergeAnnotations(List<Annotation> annotations) {
     final SplayTreeSet<int> indexes =
-        SplayTreeSet<int>.from(<int>{0, content.length - 1});
+        SplayTreeSet<int>.from(<int>{0, content.length});
     for (final Annotation a in annotations) {
       indexes.addAll(<int>[a.startIndex, a.endIndex]);
     }

--- a/learnify/mobile/lib/features/learning-space/models/post_model.dart
+++ b/learnify/mobile/lib/features/learning-space/models/post_model.dart
@@ -22,13 +22,7 @@ class Post extends BaseModel<Post> {
         title: BaseModel.getByType<String>(json['title']),
         creator: BaseModel.getByType<String>(json['creator']),
         content: BaseModel.getByType<String>(json['content']),
-        images: fetchedImages.isEmpty
-            ? const <String>[
-                'https://picsum.photos/id/1/700/400',
-                'https://picsum.photos/id/2/700/400',
-                'https://picsum.photos/id/3/700/400'
-              ]
-            : fetchedImages,
+        images: fetchedImages.isEmpty ? const <String>[] : fetchedImages,
         createdAt: BaseModel.getByType<DateTime>(json['createdAt']),
         updatedAt: BaseModel.getByType<DateTime>(json['updatedAt']),
         comments: BaseModel.embeddedListFromJson<Comment>(
@@ -40,11 +34,6 @@ class Post extends BaseModel<Post> {
         title: 'Running Apps on Different Devices',
         content:
             "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
-        images: const <String>[
-          'https://picsum.photos/id/1/700/400',
-          'https://picsum.photos/id/2/700/400',
-          'https://picsum.photos/id/3/700/400'
-        ],
         creator: 'bahricanyesil',
         createdAt: DateTime.now().subtract(const Duration(days: 1)),
         updatedAt: DateTime.now(),

--- a/learnify/mobile/lib/features/learning-space/view/components/post/post_item.dart
+++ b/learnify/mobile/lib/features/learning-space/view/components/post/post_item.dart
@@ -68,13 +68,15 @@ class PostItem extends StatelessWidget {
     final LearningSpaceViewModel viewModel =
         context.read<LearningSpaceViewModel>();
     return <Widget>[
-      Center(
-        child: BaseText(TextKeys.clickToSeeImageAnnotations,
-            style: context.labelMedium),
-      ),
-      _carouselSlider(viewModel, post, annotations, context),
-      _sliderIndicator(viewModel, post),
-      context.sizedH(1.4),
+      if (post.images.isNotEmpty)
+        Center(
+          child: BaseText(TextKeys.clickToSeeImageAnnotations,
+              style: context.labelMedium),
+        ),
+      if (post.images.isNotEmpty)
+        _carouselSlider(viewModel, post, annotations, context),
+      if (post.images.isNotEmpty) _sliderIndicator(viewModel, post),
+      if (post.images.isNotEmpty) context.sizedH(1.4),
       AnnotatableText(
         key: PageStorageKey<String>(post.content ?? 'asd'),
         content: post.content ?? '',


### PR DESCRIPTION
## Short Description

This PR is a hotfix for an empty image list. The carousel slider and indicator will not be shown when there is no image in a post.

------

## What Does This PR Include?

1. Fix empty image slider visibility
2. Fix the missing character in the post content