### PR TITLE
Fix failing profile screen test due to a hotfix before the demo

### DIFF
--- a/learnify/mobile/lib/features/home-wrapper/view-model/home_wrapper_view_model.dart
+++ b/learnify/mobile/lib/features/home-wrapper/view-model/home_wrapper_view_model.dart
@@ -5,6 +5,7 @@ import '../../../../core/base/view-model/base_view_model.dart';
 import '../../../core/managers/local/local_manager.dart';
 import '../../../product/constants/storage_keys.dart';
 import '../../auth/verification/model/user_model.dart';
+import '../../profile/view-model/profile_view_model.dart';
 
 /// View model to manage the data on home wrapper screen.
 class HomeWrapperViewModel extends BaseViewModel {

--- a/learnify/mobile/lib/features/home-wrapper/view/home_wrapper_screen.dart
+++ b/learnify/mobile/lib/features/home-wrapper/view/home_wrapper_screen.dart
@@ -19,6 +19,7 @@ import '../../../product/constants/icon_keys.dart';
 import '../../../product/constants/navigation_constants.dart';
 import '../../../product/theme/light_theme.dart';
 import '../../home/view/home_screen.dart';
+import '../../profile/view-model/profile_view_model.dart';
 import '../../profile/view/profile_screen.dart';
 import '../../search/view/search_screen.dart';
 import '../../view-learning-spaces/view/taken_ls_screen.dart';

--- a/learnify/mobile/lib/features/profile/view-model/profile_view_model.dart
+++ b/learnify/mobile/lib/features/profile/view-model/profile_view_model.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
 import '../../../../core/base/view-model/base_view_model.dart';
+import '../../../core/managers/local/local_manager.dart';
 import '../../../core/managers/network/models/l_response_model.dart';
 import '../../../product/constants/storage_keys.dart';
 import '../../auth/verification/model/user_model.dart';
@@ -58,6 +59,7 @@ class ProfileViewModel extends BaseViewModel {
   void initViewModel() {
     _profileService = ProfileService.instance;
     _picker = ImagePicker();
+    _user = LocalManager.instance.getModel(const User(), StorageKeys.user);
   }
 
   @override
@@ -90,9 +92,8 @@ class ProfileViewModel extends BaseViewModel {
     notifyListeners();
   }
 
-  Future<void> getUserName() async {
-    final User tempUser =
-        await localManager.getModel(const User(), StorageKeys.user);
+  void getUserName() {
+    final User tempUser = localManager.getModel(const User(), StorageKeys.user);
     _user = tempUser;
     _profile = Profile(username: _user?.username, email: _user?.email);
   }

--- a/learnify/mobile/lib/features/profile/view/profile_screen.dart
+++ b/learnify/mobile/lib/features/profile/view/profile_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -37,7 +36,7 @@ class ProfileScreen extends BaseView<ProfileViewModel> {
           builder: _builder,
           scrollable: true,
           hasScaffold: false,
-          futureInit: (BuildContext context) async =>
+          voidInit: (BuildContext context) =>
               context.read<ProfileViewModel>().getUserName(),
           key: key,
         );

--- a/learnify/mobile/test/profile_screen_test.dart
+++ b/learnify/mobile/test/profile_screen_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:learnify/core/managers/local/local_manager.dart';
 import 'package:learnify/core/widgets/buttons/action_button.dart';
-import 'package:learnify/core/widgets/text-field/custom_text_form_field.dart';
 import 'package:learnify/features/auth/verification/model/user_model.dart';
 import 'package:learnify/features/home-wrapper/view/home_wrapper_screen.dart';
 import 'package:learnify/features/profile/constants/widget_keys.dart';
@@ -31,11 +30,11 @@ void main() {
       final ProfileScreen profileScreen =
           tester.widget(profileFinder) as ProfileScreen;
       expect(profileFinder, findsOneWidget);
-      /*
+
       final Finder updateButtonFinder = TestHelpers.descendantFinderByKey(
           profileScreen, ProfileKeys.updateButton);
       expect(updateButtonFinder, findsOneWidget);
-      ActionButton updateButton =
+      final ActionButton updateButton =
           tester.widget(updateButtonFinder) as ActionButton;
 
       final Finder enrolledButtonFinder = TestHelpers.descendantFinderByKey(
@@ -46,30 +45,11 @@ void main() {
           profileScreen, ProfileKeys.createdLearningSpacesButton);
       expect(createdButtonFinder, findsOneWidget);
 
-      final Finder usernameFormFinder = TestHelpers.descendantFinderByKey(
-          profileScreen, ProfileKeys.usernameField);
-      expect(usernameFormFinder, findsOneWidget);
-
       final Finder biographyFormFinder = TestHelpers.descendantFinderByKey(
           profileScreen, ProfileKeys.biographyField);
       expect(biographyFormFinder, findsOneWidget);
 
       expect(updateButton.isActive, false);
-
-      final CustomTextFormField usernameField =
-          tester.widget(usernameFormFinder) as CustomTextFormField;
-      usernameField.controller?.text = 'ex';
-
-      await tester.pumpAndSettle();
-      updateButton = tester.widget(updateButtonFinder) as ActionButton;
-      expect(updateButton.isActive, true);
-
-      usernameField.controller?.text = 'hasanarisan';
-
-      await tester.pumpAndSettle();
-      updateButton = tester.widget(updateButtonFinder) as ActionButton;
-      expect(updateButton.isActive, true);
-      */
     },
   );
 }


### PR DESCRIPTION
## Short Description

This is a so small change for a failing test on mobile. Due to a hotfix, we need to do before the demo, the profile screen test became invalid and was failing. This PR fixes the problem. It does not change the functionality of the app, it just fixes the failing test due to a last-minute change made this morning. 